### PR TITLE
Fix TypeError in get_predictions_for_fasta_file

### DIFF
--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -470,8 +470,8 @@ class AnalyzeSequences(object):
 
             if i and i % self.batch_size == 0:
                 preds = self.predict(sequences)
-                sequences = np.zeros(
-                    self.batch_size, *cur_sequence_encoding.shape)
+                sequences = np.zeros((
+                    self.batch_size, *cur_sequence_encoding.shape))
                 reporter.handle_batch_predictions(preds, batch_ids)
 
             sequences[i % self.batch_size, :, :] = cur_sequence_encoding


### PR DESCRIPTION
Call to numpy.zeros incorrectly used *args instead of tuple for shape.