### PR TITLE
Fix jenkins builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
       make \
       gcc \
       libz-dev \
-      libgl1-mesa-swx11 \
+      libgl1-mesa-glx \
       && \
     apt-get autoremove --purge -y && \
     apt-get autoclean -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3
+FROM continuumio/anaconda3:2018.12
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
       make \


### PR DESCRIPTION
The first switches to a package that seems to work.  The second should pin to a specific environment so it doesn't break unexpectedly again.