### PR TITLE
FIX link to install guide

### DIFF
--- a/tutorials/getting_started_with_selene/getting_started_with_selene.ipynb
+++ b/tutorials/getting_started_with_selene/getting_started_with_selene.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This tutorial explores the core components of Selene, and should teach you everything you need to know to train a simple model on biological sequence data. \n",
     "Before starting this tutorial, you need to install Selene.\n",
-    "Instructions for installation are available [here](https://selene.flatironinstitute.org/installation.html).\n",
+    "Instructions for installation are available [here](https://selene.flatironinstitute.org/overview/installation.html).\n",
     "Lastly, if you are not familiar with neural networks, we recommend reading through this [introductory PyTorch tutorial on neural networks](https://pytorch.org/tutorials/beginner/blitz/neural_networks_tutorial.html).\n",
     "In the simplest case, we train a neural network as follows:\n",
     "\n",


### PR DESCRIPTION
The link to the installation guide in `getting_started_with_selene.ipynb` is broken.