### PR TITLE
Reset batch sequence IDs list after each batch

### DIFF
--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -294,6 +294,7 @@ class AnalyzeSequences(object):
                 sequences = np.zeros((
                     self.batch_size, *cur_sequence_encoding.shape))
                 reporter.handle_batch_predictions(preds, batch_ids)
+                batch_ids = []
 
             sequences[i % self.batch_size, :, :] = cur_sequence_encoding
 


### PR DESCRIPTION
This fixes an issue when predicting from a FASTA file where the
sequence IDs from the first batch were being used for all subsequent
batches.  The `batch_ids` list is set to an empty list before entering
into the sequence and batch loop, but prior to this patch, the
`batch_ids` list was not being cleared.  This meant that only the first
N entries in the sequence ID list, where N is the batch side were
being used in the output of the predict.  Testing on a small number of
sequences, i.e. smaller than the batch size would not reveal this issue.

This change resets the `batch_ids` list after each batch.