### PR TITLE
Fix evaluation and update quickstart tutorial

### DIFF
--- a/selene_sdk/evaluate_model.py
+++ b/selene_sdk/evaluate_model.py
@@ -131,8 +131,9 @@ class EvaluateModel(object):
         self._test_data, self._all_test_targets = \
             self.sampler.get_data_and_targets(self.batch_size, n_test_samples)
 
-        if type(self.reference_sequence) == Genome and \
-                _is_lua_trained_model(model):
+        if (hasattr(self.sampler, reference_sequence) and
+                isinstance(self.sampler.reference_sequence, Genome) and
+                _is_lua_trained_model(model)):
             Genome.update_bases_order(['A', 'G', 'C', 'T'])
 
     def _get_feature_from_index(self, index):

--- a/selene_sdk/utils/config_utils.py
+++ b/selene_sdk/utils/config_utils.py
@@ -161,7 +161,7 @@ def execute(operations, configs, output_dir):
 
     """
     model = None
-    trainer = None
+    train_model = None
     for op in operations:
         if op == "train":
             model, loss, optim, optim_kwargs = initialize_model(
@@ -188,8 +188,8 @@ def execute(operations, configs, output_dir):
             train_model.train_and_validate()
 
         elif op == "evaluate":
-            if trainer is not None:
-                trainer.evaluate()
+            if train_model is not None:
+                train_model.evaluate()
 
             if not model:
                 model, loss = initialize_model(

--- a/tutorials/quickstart_training/quickstart_training.ipynb
+++ b/tutorials/quickstart_training/quickstart_training.ipynb
@@ -23,7 +23,7 @@
     "Download the compressed data from here:\n",
     "\n",
     "```sh\n",
-    "wget https://zenodo.org/record/1319886/files/selene_quickstart_tutorial.tar.gz\n",
+    "wget https://zenodo.org/record/1443558/files/selene_quickstart.tar.gz\n",
     "```\n",
     "\n",
     "Extract it and `mv` all files from the extracted directory `selene_quickstart_tutorial` to the current directory."


### PR DESCRIPTION
#### Reference Issues/PRs
This should address problems found in #107 and #108

#### What does this implement/fix? Explain your changes.
- Evaluation should now occur after training completes, without the need to specify the `evaluate_model` object in the configuration file.
- The `quickstart_training` tutorial now has the correct zenodo url.
- `EvaluateModel` now only checks reference sequence type for samplers with reference sequences.

#### What testing did you do to verify the changes in this PR?
I re-ran the `quickstart_training` tutorial on a machine with a GPU and manually verified the output.
