### PR TITLE
[WIP] Wrapping multiple trained models to concatenate model predictions 

### DIFF
--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -392,7 +392,7 @@ class AnalyzeSequences(object):
             batch_ids.append(label)
             sequences[i % self.batch_size, :, :] = encoding
 
-        if i % self.batch_size != 0:
+        if (batch_ids and i == 0) or i % self.batch_size != 0:
             sequences = sequences[:i % self.batch_size + 1, :, :]
             preds = predict(self.model, sequences, use_cuda=self.use_cuda)
             reporter.handle_batch_predictions(preds, batch_ids)

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -54,9 +54,9 @@ class AnalyzeSequences(object):
         a list of paths, assumes that the `model` passed in is of type
         `selene_sdk.utils.MultiModelWrapper`, which takes in a list of
         models. The paths must be ordered the same way the models
-        are ordered in that list. Currently Selene's config file CLI does
-        NOT support using the MultiModelWrapper and will not accept a list
-        of model weights files as input to `trained_model_path`.
+        are ordered in that list. `list(str)` input is an API-only function--
+        Selene's config file CLI does not support the `MultiModelWrapper`
+        functionality at this time.
     sequence_length : int
         The length of sequences that the model is expecting.
     features : list(str)

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -48,9 +48,15 @@ class AnalyzeSequences(object):
     ----------
     model : torch.nn.Module
         A sequence-based model architecture.
-    trained_model_path : str
-        The path to the weights file for a trained sequence-based model.
-        Architecture must match `model`.
+    trained_model_path : str or list(str)
+        The path(s) to the weights file for a trained sequence-based model.
+        For a single path, the model architecture must match `model`. For
+        a list of paths, assumes that the `model` passed in is of type
+        `selene_sdk.utils.MultiModelWrapper`, which takes in a list of
+        models. The paths must be ordered the same way the models
+        are ordered in that list. Currently Selene's config file CLI does
+        NOT support using the MultiModelWrapper and will not accept a list
+        of model weights files as input to `trained_model_path`.
     sequence_length : int
         The length of sequences that the model is expecting.
     features : list(str)
@@ -123,16 +129,30 @@ class AnalyzeSequences(object):
         """
         Constructs a new `AnalyzeSequences` object.
         """
-        trained_model = torch.load(
-            trained_model_path,
-            map_location=lambda storage, location: storage)
+        self.model = model
 
-        if "state_dict" not in trained_model:
-            self.model = load_model_from_state_dict(
-                trained_model, model)
+        if isinstance(trained_model_path, str):
+            trained_model = torch.load(
+                trained_model_path,
+                map_location=lambda storage, location: storage)
+
+            load_model_from_state_dict(
+                trained_model, self.model)
+        elif hasattr(trained_model_path, '__len__'):
+            state_dicts = []
+            for mp in trained_model_path:
+                state_dict = torch.load(
+                    mp, map_location=lambda storage, location: storage)
+                state_dicts.append(state_dict)
+
+            for (sd, sub_model) in zip(state_dicts, self.model.sub_models):
+                load_model_from_state_dict(sd, sub_model)
         else:
-            self.model = load_model_from_state_dict(
-                trained_model["state_dict"], model)
+            raise ValueError(
+                '`trained_model_path` should be a str or list of strs '
+                'specifying the full paths to model weights files, but was '
+                'type {0}.'.format(type(trained_model_path)))
+
         self.model.eval()
 
         self.data_parallel = data_parallel

--- a/selene_sdk/utils/__init__.py
+++ b/selene_sdk/utils/__init__.py
@@ -19,6 +19,7 @@ from .config import instantiate
 from .config_utils import initialize_model
 from .config_utils import execute
 from .config_utils import parse_configs_and_run
+from .multi_model_wrapper import MultiModelWrapper
 from .non_strand_specific_module import NonStrandSpecific
 from .example_model import DeeperDeepSEA
 
@@ -36,5 +37,6 @@ __all__ = ["_is_lua_trained_model",
            "initialize_model",
            "execute",
            "parse_configs_and_run",
+           "MultiModelWrapper",
            "NonStrandSpecific",
            "DeeperDeepSEA"]

--- a/selene_sdk/utils/multi_model_wrapper.py
+++ b/selene_sdk/utils/multi_model_wrapper.py
@@ -37,6 +37,10 @@ class MultiModelWrapper(nn.Module):
         self.sub_models = sub_models
         self._concat_dim = concat_dim
 
+    def eval(self):
+        for sm in self.sub_models:
+            sm.eval()
+
     def forward(self, x):
         return torch.cat(
             [sm(x) for sm in self.sub_models], self._concat_dim)

--- a/selene_sdk/utils/multi_model_wrapper.py
+++ b/selene_sdk/utils/multi_model_wrapper.py
@@ -1,0 +1,43 @@
+"""
+This module specifies the MultiModelWrapper class, currently intended for
+use through Selene's API (as opposed to the CLI).
+
+Loads multiple models and concatenates their outputs.
+"""
+import torch
+import torch.nn as nn
+
+
+class MultiModelWrapper(nn.Module):
+
+    def __init__(self, sub_models, concat_dim=1):
+        """
+        The multi-model wrapper class can be used to concatenate the
+        outputs of multiple models along a pre-specified axis. The wrapper
+        can be used to load and run multiple trained models during prediction
+        functions. We have not tested this class for use in simultaneous
+        training of multiple models. We also have not yet provided support
+        for using this class through the CLI.
+
+        This class can be used to initialize
+        `selene_sdk.predict.AnalyzeSequences` with a corresponding list of
+        `trained_model_path`s. Please ensure the ordering of the two lists
+        (the `sub_models` here and `trained_model_path` in AnalyzeSequences)
+        match.
+
+        Parameters
+        ----------
+        sub_models : list(torch.nn.Module)
+            The 'sub-models' that are used in this multi-model wrapper class.
+        concat_dim : int, optional
+            Default is 1. The dimension along which to concatenate the models'
+            predictions.
+        """
+        super(MultiModelWrapper, self).__init__()
+        self.sub_models = sub_models
+        self._concat_dim = concat_dim
+
+    def forward(self, x):
+        return torch.cat(
+            [sm(x) for sm in self.sub_models], self._concat_dim)
+

--- a/selene_sdk/utils/multi_model_wrapper.py
+++ b/selene_sdk/utils/multi_model_wrapper.py
@@ -15,14 +15,13 @@ class MultiModelWrapper(nn.Module):
         The multi-model wrapper class can be used to concatenate the
         outputs of multiple models along a pre-specified axis. The wrapper
         can be used to load and run multiple trained models during prediction
-        functions. We have not tested this class for use in simultaneous
-        training of multiple models. We also have not yet provided support
-        for using this class through the CLI.
+        functions. This class should not be used for training. We also have
+        not yet provided support for using this class through the CLI.
 
         This class can be used to initialize
         `selene_sdk.predict.AnalyzeSequences` with a corresponding list of
         `trained_model_path`s. Please ensure the ordering of the two lists
-        (the `sub_models` here and `trained_model_path` in AnalyzeSequences)
+        (`sub_models` here and `trained_model_path` in AnalyzeSequences)
         match.
 
         Parameters

--- a/selene_sdk/utils/utils.py
+++ b/selene_sdk/utils/utils.py
@@ -89,6 +89,9 @@ def load_model_from_state_dict(state_dict, model):
         If model state dict keys do not match the keys in `state_dict`.
 
     """
+    if 'state_dict' in state_dict:
+        state_dict = state_dict['state_dict']
+
     model_keys = model.state_dict().keys()
     state_dict_keys = state_dict.keys()
 

--- a/selene_sdk/utils/utils.py
+++ b/selene_sdk/utils/utils.py
@@ -11,14 +11,18 @@ import traceback
 
 import numpy as np
 
+from .multi_model_wrapper import MultiModelWrapper
+
 
 def _is_lua_trained_model(model):
     if hasattr(model, 'from_lua'):
         return model.from_lua
-
     check_model = model
     if hasattr(model, 'model'):
         check_model = model.model
+    elif type(model) == MultiModelWrapper and \
+            hasattr(model, 'sub_models'):
+        check_model = model.sub_models[0]
     setattr(model, "from_lua", False)
     setattr(check_model, "from_lua", False)
     for m in check_model.modules():


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Main changes are based on internal discussions. I also include a bugfix addressing issue #118. 

#### What does this implement/fix? Explain your changes.
Add a wrapper class and some edits to the API to allow users to pass in multiple trained model paths and get a single vector of predictions concatenating all the different model predictions.

All models must take in the same sequence length and input dimensions (i.e. 4-D lua-trained vs 3-D)

Also fix handling single-entry bed files for `get_predictions_for_bed_file`.

#### What testing did you do to verify the changes in this PR?
Use this wrapper on a few different pairs of trained models.

Ran `get_predictions_for_bed_file` on a few different BED file examples (along with single-entry bed file).

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
