### PR TITLE
annotate incompletely sequenced/assembled regions and filter blacklisted regions during prediction

### DIFF
--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -108,12 +108,12 @@ def read_vcf_file(input_path,
                 lhs_radius, rhs_radius = seq_context
                 start = pos + len(ref) // 2 - lhs_radius
                 end = pos + len(ref) // 2 + rhs_radius
-                if not reference_sequence.coords_in_bounds(chrom, start, end) \
-                        and output_NAs_to_file:
-                    with open(output_NAs_to_file, 'a') as file_handle:
-                        file_handle.write(
-                            "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(
-                                chrom, pos, name, ref, alt, strand))
+                if not reference_sequence.coords_in_bounds(chrom, start, end):
+                    if output_NAs_to_file:
+                        with open(output_NAs_to_file, 'a') as file_handle:
+                            file_handle.write(
+                                "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(
+                                    chrom, pos, name, ref, alt, strand))
                     continue
             for a in alt.split(','):
                 variants.append((chrom, pos, name, ref, a, strand))

--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -61,6 +61,9 @@ def read_vcf_file(input_path,
     variants = []
 
     with open(input_path, 'r') as file_handle:
+        if output_NAs_to_file:
+            na_file_handle =  open(output_NAs_to_file, 'w')
+    
         lines = file_handle.readlines()
         index = 0
         for index, line in enumerate(lines):
@@ -110,13 +113,14 @@ def read_vcf_file(input_path,
                 end = pos + len(ref) // 2 + rhs_radius
                 if not reference_sequence.coords_in_bounds(chrom, start, end):
                     if output_NAs_to_file:
-                        with open(output_NAs_to_file, 'w') as file_handle:
-                            file_handle.write(
-                                "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(
-                                    chrom, pos, name, ref, alt, strand))
+                        na_file_handle.write(
+                            "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(
+                                chrom, pos, name, ref, alt, strand))
                     continue
             for a in alt.split(','):
                 variants.append((chrom, pos, name, ref, a, strand))
+        if output_NAs_to_file:
+            na_file_handle.close()
     return variants
 
 

--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -110,7 +110,7 @@ def read_vcf_file(input_path,
                 end = pos + len(ref) // 2 + rhs_radius
                 if not reference_sequence.coords_in_bounds(chrom, start, end):
                     if output_NAs_to_file:
-                        with open(output_NAs_to_file, 'a') as file_handle:
+                        with open(output_NAs_to_file, 'w') as file_handle:
                             file_handle.write(
                                 "{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(
                                     chrom, pos, name, ref, alt, strand))

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -299,7 +299,7 @@ class AnalyzeSequences(object):
                 if reference_sequence:
                     if not reference_sequence.coords_in_bounds(chrom, seq_start, seq_end):
                         if output_NAs_to_file:
-                            with open(output_NAs_to_file, 'a') as file_handle:
+                            with open(output_NAs_to_file, 'w') as file_handle:
                                 file_handle.write(
                                     "{0}\t{1}\t{2}\n".format(
                                         chrom, seq_start, seq_end))

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -890,7 +890,6 @@ class AnalyzeSequences(object):
             output_NAs_to_file="{0}.NA".format(output_path_prefix),
             seq_context=(self._start_radius, self._end_radius),
             reference_sequence=self.reference_sequence)
-        print(len(variants))
         reporters = self._initialize_reporters(
             save_data,
             output_path_prefix,

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -560,16 +560,12 @@ class AnalyzeSequences(object):
         if input_path.endswith('.fa') or input_path.endswith('.fasta'):
             self.get_predictions_for_fasta_file(
                 input_path, output_dir, output_format=output_format)
-        elif input_path.endswith('.bed'):
+        else:
             self.get_predictions_for_bed_file(
                 input_path,
                 output_dir,
                 output_format=output_format,
                 strand_index=strand_index)
-        else:
-            raise ValueError("Unrecognized file extension for "
-                            "`input_path`. Supported file extensions are '.fa'"
-                            ", '.fasta', or '.bed'.")
 
     def in_silico_mutagenesis_predict(self,
                                       sequence,

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -283,11 +283,8 @@ class AnalyzeSequences(object):
                     continue  # TODO: divert to NA file?
                 start, end = int(start), int(end)
                 mid_pos = start + ((end - start) // 2)
-                seq_start = max(
-                    mid_pos - self._start_radius, 0)
-                seq_end = min(
-                    mid_pos + self._end_radius,
-                    self.reference_sequence.len_chrs[chrom])
+                seq_start = mid_pos - self._start_radius
+                seq_end = mid_pos + self._end_radius
                 sequences.append((chrom, seq_start, seq_end, strand))
                 labels.append((i, chrom, start, end, strand))
         return sequences, labels

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -533,15 +533,19 @@ class AnalyzeSequences(object):
             mark this sequence or region as `contains_unk = True`.
 
         """
-        try:
+        if input_path.endswith('.fa') or input_path.endswith('.fasta'):
             self.get_predictions_for_fasta_file(
                 input_path, output_dir, output_format=output_format)
-        except pyfaidx.FastaIndexingError:
+        elif input_path.endswith('.bed'):
             self.get_predictions_for_bed_file(
                 input_path,
                 output_dir,
                 output_format=output_format,
                 strand_index=strand_index)
+        else:
+            raise ValueError("Unrecognized file extension for "
+                            "`input_path`. Supported file extensions are '.fa'"
+                            ", '.fasta', or '.bed'.")
 
     def in_silico_mutagenesis_predict(self,
                                       sequence,

--- a/selene_sdk/predict/predict_handlers/handler.py
+++ b/selene_sdk/predict/predict_handlers/handler.py
@@ -231,7 +231,9 @@ class PredictionsHandler(metaclass=ABCMeta):
                     filename_prefix, labels_filename)
             self._labels_filepath = os.path.join(output_path, labels_filename)
             # create the file
-            open(self._labels_filepath, 'w+')
+            label_handle = open(self._labels_filepath, 'w+')
+            label_handle.write("{0}\n".format(
+                                '\t'.join(self._columns_for_ids)))
 
     def _reached_mem_limit(self):
         mem_used = (self._results[0].nbytes * len(self._results) +

--- a/selene_sdk/predict/predict_handlers/handler.py
+++ b/selene_sdk/predict/predict_handlers/handler.py
@@ -211,12 +211,11 @@ class PredictionsHandler(metaclass=ABCMeta):
                     '\t'.join(column_names)))
         elif self._output_format == "hdf5":
             self._output_filepath = "{0}.h5".format(scores_filepath)
-            with h5py.File(self._output_filepath, 'a') as output_handle:
-                if "data" not in output_handle:
-                    output_handle.create_dataset(
-                        "data",
-                        (self._output_size, len(self._features)),
-                        dtype='float64')
+            with h5py.File(self._output_filepath, 'w') as output_handle:
+                output_handle.create_dataset(
+                    "data",
+                    (self._output_size, len(self._features)),
+                    dtype='float64')
             self._hdf5_start_index = 0
 
             if not self._write_labels:

--- a/selene_sdk/sequences/genome.py
+++ b/selene_sdk/sequences/genome.py
@@ -463,8 +463,8 @@ class Genome(Sequence):
                                  strand='+',
                                  pad=False):
         """Gets the one-hot encoding of the genomic sequence at the
-        queried coordinates and check whether the output sequence
-        contains unknown base(s).
+        queried coordinates and check whether the sequence contains 
+        unknown base(s).
 
         Parameters
         ----------

--- a/selene_sdk/sequences/genome.py
+++ b/selene_sdk/sequences/genome.py
@@ -33,8 +33,8 @@ def _not_blacklist_region(chrom, start, end, blacklist_tabix):
     Returns
     -------
     bool
-        True if the coordinates are not overlaping with blacklist regions
-        (if specified). Otherwise, return False.
+        False if the coordinates are overlaping with blacklist regions
+        (if specified). Otherwise, return True.
     
     
     """

--- a/selene_sdk/sequences/genome.py
+++ b/selene_sdk/sequences/genome.py
@@ -456,7 +456,7 @@ class Genome(Sequence):
         encoding = self.sequence_to_encoding(sequence)
         return encoding
 
-    def get_encoding_from_coords_check_unknown(self,
+    def get_encoding_from_coords_check_unk(self,
                                  chrom,
                                  start,
                                  end,
@@ -495,7 +495,6 @@ class Genome(Sequence):
             or (if a blacklist exists) the region overlaps with a blacklist
             region. In these cases, it will return an empty encoding--that is,
             `L` = 0 for the NumPy array returned.
-
             * `tuple[1]` is the boolean value that indicates whether the
             sequence contains any unknown base(s) specified in self.UNK_BASE
 

--- a/selene_sdk/sequences/genome.py
+++ b/selene_sdk/sequences/genome.py
@@ -308,7 +308,7 @@ class Genome(Sequence):
         start : int
             The 0-based start coordinate of the sequence.
         end : int
-            One past the 0-based last position in the sequence.'.
+            One past the 0-based last position in the sequence.
 
         Returns
         -------

--- a/selene_sdk/sequences/genome.py
+++ b/selene_sdk/sequences/genome.py
@@ -14,10 +14,45 @@ from .sequence import Sequence
 from .sequence import sequence_to_encoding
 from .sequence import encoding_to_sequence
 
+def _not_blacklist_region(chrom, start, end, blacklist_tabix):
+    """
+    Check if the input coordinates are not overlapping with blacklist regions.
+    
+    Parameters
+    ----------
+    chrom : str
+        The name of the chromosomes, e.g. "chr1".
+    start : int
+        The 0-based start coordinate of the sequence.
+    end : int
+        One past the last coordinate of the sequence.
+    blacklist_tabix : tabix.open or None, optional
+        Default is `None`. Tabix file handle if a file of blacklist regions
+        is available.
+    
+    Returns
+    -------
+    bool
+        True if the coordinates are not overlaping with blacklist regions
+        (if specified). Otherwise, return False.
+    
+    
+    """
+    if blacklist_tabix is not None:
+        try:
+            rows = blacklist_tabix.query(chrom, start, end)
+            for row in rows:
+                return False
+        except tabix.TabixError:
+            pass
+    return True
+
+
 def _check_coords(len_chrs,
                   chrom,
                   start,
                   end,
+                  pad=False,
                   blacklist_tabix=None):
     """
     Check if the input coordinates are valid.
@@ -32,41 +67,30 @@ def _check_coords(len_chrs,
         The 0-based start coordinate of the sequence.
     end : int
         One past the last coordinate of the sequence.
+    pad : bool, optional
+        Default is `False`. Allow coordinates that are partially
+        out of bounds.
     blacklist_tabix : tabix.open or None, optional
-        Default is `None`. Tabix file handle if a file of blacklisted regions
+        Default is `None`. Tabix file handle if a file of blacklist regions
         is available.
-        
+
     Returns
     -------
     bool
-        True if the coordinates are valid (`start` and `end` are within 
+        True if the coordinates are valid (`start` and `end` are within
         chromosome boundaries and not overlaping with blacklist regions
         (if specified). Otherwise, return False.
 
-    Raises
-    ------
-    ValueError
-        If the input char to `strand` is not one of the specified
-        choices.
+
     """
-    if chrom not in len_chrs:
-        return False
+    return chrom in len_chrs and \
+         start < len_chrs[chrom] and \
+         start < end and \
+         end > 0 and \
+         (start >= 0 if not pad else True) and \
+         (end <= len_chrs[chrom] if not pad else True) and \
+         _not_blacklist_region(chrom, start, end, blacklist_tabix)
 
-    if start >= len_chrs[chrom]:
-        return False
-
-    if start >= end:
-        return False
-
-    if blacklist_tabix is not None:
-        try:
-            rows = blacklist_tabix.query(chrom, start, end)
-            for row in rows:
-                return False
-        except tabix.TabixError:
-            pass
-            
-    return True
 
 
 def _get_sequence_from_coords(len_chrs,
@@ -100,7 +124,7 @@ def _get_sequence_from_coords(len_chrs,
         in-bounds query and then pad the sequence to return the desired
         sequence length.
     blacklist_tabix : tabix.open or None, optional
-        Default is `None`. Tabix file handle if a file of blacklisted regions
+        Default is `None`. Tabix file handle if a file of blacklist regions
         is available.
 
     Returns
@@ -115,8 +139,14 @@ def _get_sequence_from_coords(len_chrs,
         choices.
 
     """
-    if not _check_coords(len_chrs, chrom, start, end, blacklist_tabix):
-        return "" 
+
+    if not _check_coords(len_chrs,
+        chrom,
+        start,
+        end,
+        pad=pad,
+        blacklist_tabix=blacklist_tabix):
+        return ""
 
     if strand != '+' and strand != '-' and strand != '.':
         raise ValueError(
@@ -298,9 +328,9 @@ class Genome(Sequence):
     def coords_in_bounds(self, chrom, start, end):
         """
         Check if the region we want to query is within the bounds of the
-        queried chromosome and non-overlapping with blacklist regions 
+        queried chromosome and non-overlapping with blacklist regions
         (if given).
-                
+
         Parameters
         ----------
         chrom : str
@@ -322,7 +352,7 @@ class Genome(Sequence):
                              start,
                              end,
                              blacklist_tabix=self._blacklist_tabix)
-  
+
     def get_sequence_from_coords(self,
                                  chrom,
                                  start,
@@ -401,15 +431,17 @@ class Genome(Sequence):
             and/or `end` are out of bounds to return a sequence of length
             `end - start`.
 
+
         Returns
         -------
-        numpy.ndarray, dtype=bool
+        numpy.ndarray, dtype=numpy.float32
             The :math:`L \\times 4` encoding of the sequence, where
             :math:`L = end - start`, unless `chrom` cannot be found
             in the input FASTA, `start` or `end` are out of bounds,
-            or (if a blacklist exists) the region overlaps with a blacklisted
+            or (if a blacklist exists) the region overlaps with a blacklist
             region. In these cases, it will return an empty encoding--that is,
             `L` = 0 for the NumPy array returned.
+
 
         Raises
         ------
@@ -423,6 +455,63 @@ class Genome(Sequence):
             chrom, start, end, strand=strand, pad=pad)
         encoding = self.sequence_to_encoding(sequence)
         return encoding
+
+    def get_encoding_from_coords_check_unknown(self,
+                                 chrom,
+                                 start,
+                                 end,
+                                 strand='+',
+                                 pad=False):
+        """Gets the one-hot encoding of the genomic sequence at the
+        queried coordinates and check whether the output sequence
+        contains unknown base(s).
+
+        Parameters
+        ----------
+        chrom : str
+            The name of the chromosome or region, e.g. "chr1".
+        start : int
+            The 0-based start coordinate of the first position in the
+            sequence.
+        end : int
+            One past the 0-based last position in the sequence.
+        strand : {'+', '-', '.'}, optional
+            Default is '+'. The strand the sequence is located on. '.' is
+            treated as '+'.
+        pad : bool, optional
+            Default is `False`. Pad the output sequence with 'N' if `start`
+            and/or `end` are out of bounds to return a sequence of length
+            `end - start`.
+
+
+        Returns
+        -------
+        tuple(numpy.ndarray, bool)
+
+            * `tuple[0]` is the :math:`L \\times 4` encoding of the sequence
+            containing data of `numpy.float32` type, where
+            :math:`L = end - start`, unless `chrom` cannot be found
+            in the input FASTA, `start` or `end` are out of bounds,
+            or (if a blacklist exists) the region overlaps with a blacklist
+            region. In these cases, it will return an empty encoding--that is,
+            `L` = 0 for the NumPy array returned.
+
+            * `tuple[1]` is the boolean value that indicates whether the
+            sequence contains any unknown base(s) specified in self.UNK_BASE
+
+
+        Raises
+        ------
+        ValueError
+            If the input char to `strand` is not one of the specified
+            choices.
+            (Raised in the call to `self.get_sequence_from_coords`)
+        """
+        sequence = self.get_sequence_from_coords(
+            chrom, start, end, strand=strand, pad=pad)
+        encoding = self.sequence_to_encoding(sequence)
+        return encoding, self.UNK_BASE in sequence
+
 
     @classmethod
     def sequence_to_encoding(cls, sequence):


### PR DESCRIPTION
#### Reference Issues/PRs
This pull request mainly focuses on improving annotation or filtering incomplete or blacklisted regions of the genome. We also addressed some issues related to prediction according to internal discussions.

#### What does this implement/fix? Explain your changes.

New:
* Add check for whether a input sequence includes UNK_BASE (e.g "N" for DNA sequence). If true, then output a warning and write `True` to the "contains_unk" column in an output file.
* For vcf and bed, blacklisted region variants/intervals (if specified) are now directed to .NA files and do not get predicted.

Changes / fixes:
* Add a header row to the row_labels output file (when hdf5 format output is specified)
* Now determine whether the input file is fasta or bed based on the file extension (prevent generating empty fai files on non-fasta input)
* Open hdf5 output file with 'w' instead of 'a', so now the output hdf5 file is always truncated to zero length first if the file exists.
* Open .NA output file with 'w' instead of 'a', so now the output .NA file is always truncated to zero length first if the file exists.

#### What testing did you do to verify the changes in this PR?
Ran prediction for a few small fasta, bed, and vcf files with both regions with “N”s and regions without “N”s.
Made predictions for a few large bed and vcf files with and without blacklisted regions specified.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->