### PR TITLE
bugfix, allow CUDA-enabled MultiModelWrapper 

### DIFF
--- a/selene_sdk/utils/multi_model_wrapper.py
+++ b/selene_sdk/utils/multi_model_wrapper.py
@@ -36,6 +36,10 @@ class MultiModelWrapper(nn.Module):
         self.sub_models = sub_models
         self._concat_dim = concat_dim
 
+    def cuda(self):
+        for sm in self.sub_models:
+            sm.cuda()
+
     def eval(self):
         for sm in self.sub_models:
             sm.eval()


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #122, raised by @j-funk 

#### What does this implement/fix? Explain your changes.
I added a method `cuda`, similar to `eval`, that iterates through sub-models in the MultiModelWrapper object and calls each sub-model's `cuda` method. 

#### What testing did you do to verify the changes in this PR?
Re-ran SeqWeaver variant effect prediction testing with `use_cuda=True`

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
