### PR TITLE
Simplify variant effect prediction reverse strand handling

### DIFF
--- a/docs/source/overview/cli.md
+++ b/docs/source/overview/cli.md
@@ -112,8 +112,8 @@ train_model: !obj:selene_sdk.TrainModel {
     data_parallel: True,
     logging_verbosity: 2,
     metrics: {
-        roc_auc: !import:sklearn.metrics.roc_auc_score,
-        average_precision: !import:sklearn.metrics.average_precision_score
+        roc_auc: !import sklearn.metrics.roc_auc_score,
+        average_precision: !import sklearn.metrics.average_precision_score
     },
     checkpoint_resume: False    
 }

--- a/selene_sdk/predict/_common.py
+++ b/selene_sdk/predict/_common.py
@@ -35,6 +35,43 @@ def get_reverse_complement(allele, complementary_base_dict):
     return ''.join(list(reversed(a_complement)))
 
 
+def get_reverse_complement_encoding(allele_encoding,
+                                    complementary_base_encoding,
+                                    index_to_base):
+    """
+    Get the reverse complement of the input allele one-hot encoding.
+
+    Parameters
+    ----------
+    allele : str
+        The sequence allele encoding, :math:`L \\times 4`
+    complementary_base_dict : dict(str: str)
+        The dictionary that maps each base to its complement
+    index_to_base : dict(str: int)
+        The dictionary that maps each index to the base
+
+    Returns
+    -------
+    np.ndarray
+        The reverse complement encoding of the allele, shape
+        :math:`L \\times 4`.
+
+    """
+    base_to_index = {b: ix for (ix, b) in index_to_base.items()}
+    rc_allele = np.zeros(allele.shape)
+    for i, base_enc in enumerate(allele):
+        base_ix = np.where(base_enc == 1)[0]
+        rc_i = len(rc_allele) - 1 - i
+        if not ix:
+            rc_allele[rc_i] = base_enc
+        else:
+            rc_base = complementary_base_dict[
+                index_to_base[base_ix]]
+            rc_base_ix = base_to_index[rc_base]
+            rc_allele[rc_i, rc_base_ix] = 1
+    return rc_allele
+
+
 def predict(model, batch_sequences, use_cuda=False):
     """
     Return model predictions for a batch of sequences.

--- a/selene_sdk/predict/_common.py
+++ b/selene_sdk/predict/_common.py
@@ -36,8 +36,8 @@ def get_reverse_complement(allele, complementary_base_dict):
 
 
 def get_reverse_complement_encoding(allele_encoding,
-                                    complementary_base_dict,
-                                    index_to_base):
+                                    bases_arr,
+                                    complementary_base_dict):
     """
     Get the reverse complement of the input allele one-hot encoding.
 
@@ -45,10 +45,10 @@ def get_reverse_complement_encoding(allele_encoding,
     ----------
     allele_encoding : numpy.ndarray
         The sequence allele encoding, :math:`L \\times 4`
+    bases_arr : list(str)
+        The base ordering for the one-hot encoding
     complementary_base_dict : dict(str: str)
         The dictionary that maps each base to its complement
-    index_to_base : dict(str: int)
-        The dictionary that maps each index to the base
 
     Returns
     -------
@@ -57,19 +57,10 @@ def get_reverse_complement_encoding(allele_encoding,
         :math:`L \\times 4`.
 
     """
-    base_to_index = {b: ix for (ix, b) in index_to_base.items()}
-    rc_allele = np.zeros(allele_encoding.shape)
-    for i, base_enc in enumerate(allele_encoding):
-        base_ix = np.where(base_enc == 1)[0]
-        rc_i = len(rc_allele) - 1 - i
-        if len(base_ix) != 1:
-            rc_allele[rc_i] = base_enc
-        else:
-            rc_base = complementary_base_dict[
-                index_to_base[base_ix[0]]]
-            rc_base_ix = base_to_index[rc_base]
-            rc_allele[rc_i, rc_base_ix] = 1
-    return rc_allele
+    base_ixs = {b: i for (i, b) in enumerate(bases_arr)}
+    complement_indices = [
+        base_ixs[complementary_base_dict[b]] for b in bases_arr]
+    return allele_encoding[:, complement_indices][::-1, :]
 
 
 def predict(model, batch_sequences, use_cuda=False):

--- a/selene_sdk/predict/_common.py
+++ b/selene_sdk/predict/_common.py
@@ -36,14 +36,14 @@ def get_reverse_complement(allele, complementary_base_dict):
 
 
 def get_reverse_complement_encoding(allele_encoding,
-                                    complementary_base_encoding,
+                                    complementary_base_dict,
                                     index_to_base):
     """
     Get the reverse complement of the input allele one-hot encoding.
 
     Parameters
     ----------
-    allele : str
+    allele_encoding : numpy.ndarray
         The sequence allele encoding, :math:`L \\times 4`
     complementary_base_dict : dict(str: str)
         The dictionary that maps each base to its complement
@@ -58,15 +58,15 @@ def get_reverse_complement_encoding(allele_encoding,
 
     """
     base_to_index = {b: ix for (ix, b) in index_to_base.items()}
-    rc_allele = np.zeros(allele.shape)
-    for i, base_enc in enumerate(allele):
+    rc_allele = np.zeros(allele_encoding.shape)
+    for i, base_enc in enumerate(allele_encoding):
         base_ix = np.where(base_enc == 1)[0]
         rc_i = len(rc_allele) - 1 - i
-        if not ix:
+        if not base_ix or len(base_ix) > 1:
             rc_allele[rc_i] = base_enc
         else:
             rc_base = complementary_base_dict[
-                index_to_base[base_ix]]
+                index_to_base[base_ix[0]]]
             rc_base_ix = base_to_index[rc_base]
             rc_allele[rc_i, rc_base_ix] = 1
     return rc_allele

--- a/selene_sdk/predict/_common.py
+++ b/selene_sdk/predict/_common.py
@@ -62,7 +62,7 @@ def get_reverse_complement_encoding(allele_encoding,
     for i, base_enc in enumerate(allele_encoding):
         base_ix = np.where(base_enc == 1)[0]
         rc_i = len(rc_allele) - 1 - i
-        if not base_ix or len(base_ix) > 1:
+        if len(base_ix) != 1:
             rc_allele[rc_i] = base_enc
         else:
             rc_base = complementary_base_dict[

--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -127,10 +127,9 @@ def read_vcf_file(input_path,
 
 def _get_ref_idxs(seq_len, ref_len):
     mid = seq_len // 2
-    if ref_len == 1:
-        start_pos = mid - 1
-    else:
-        start_pos = mid - ref_len // 2 - 1
+    if seq_len % 2 == 0:
+        mid -= 1
+    start_pos = mid - ref_len // 2
     end_pos = start_pos + ref_len
     return (start_pos, end_pos)
 

--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -210,7 +210,7 @@ def _process_alt(chrom,
             pos + 1 + ref_len,
             end + math.ceil(ref_len / 2.) - math.ceil(alt_len / 2.),
             pad=True)
-            sequence = lhs + alt + rhs
+        sequence = lhs + alt + rhs
         return reference_sequence.sequence_to_encoding(
             sequence)
 

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -999,12 +999,16 @@ class AnalyzeSequences(object):
                               "column of the .tsv or the row_labels .txt file".format(
                                   chrom, pos, name, ref, alt, strand, seq_at_ref))
             batch_ids.append((chrom, pos, name, ref, alt, strand, match, contains_unk))
-            batch_ref_seqs.append(ref_sequence_encoding)
             if strand == '-':
+                ref_sequence_encoding = get_reverse_complement_encoding(
+                    ref_sequence_encoding,
+                    self.reference_sequence.COMPLEMENTARY_BASE_DICT,
+                    self.reference_sequence.INDEX_TO_BASE)
                 alt_sequence_encoding = get_reverse_complement_encoding(
                     alt_sequence_encoding,
                     self.reference_sequence.COMPLEMENTARY_BASE_DICT,
                     self.reference_sequence.INDEX_TO_BASE)
+            batch_ref_seqs.append(ref_sequence_encoding)
             batch_alt_seqs.append(alt_sequence_encoding)
 
             if len(batch_ref_seqs) >= self.batch_size:

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -15,6 +15,7 @@ import torch.nn as nn
 from ._common import _pad_sequence
 from ._common import _truncate_sequence
 from ._common import get_reverse_complement
+from ._common import get_reverse_complement_encoding
 from ._common import predict
 from ._in_silico_mutagenesis import _ism_sample_id
 from ._in_silico_mutagenesis import in_silico_mutagenesis_sequences
@@ -1001,7 +1002,9 @@ class AnalyzeSequences(object):
             batch_ref_seqs.append(ref_sequence_encoding)
             if strand == '-':
                 alt_sequence_encoding = get_reverse_complement_encoding(
-                    alt_sequence_encoding)
+                    alt_sequence_encoding,
+                    self.reference_sequence.COMPLEMENTARY_BASE_DICT,
+                    self.reference_sequence.INDEX_TO_BASE)
             batch_alt_seqs.append(alt_sequence_encoding)
 
             if len(batch_ref_seqs) >= self.batch_size:

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -165,10 +165,10 @@ class AnalyzeSequences(object):
 
         self.sequence_length = sequence_length
 
-        self._start_radius = int(sequence_length / 2)
+        self._start_radius = sequence_length // 2
         self._end_radius = self._start_radius
         if sequence_length % 2 != 0:
-            self._end_radius += 1
+            self._start_radius += 1
 
         self.batch_size = batch_size
         self.features = features

--- a/selene_sdk/predict/tests/test__common.py
+++ b/selene_sdk/predict/tests/test__common.py
@@ -1,0 +1,52 @@
+"""
+Test methods in the _common methods module
+"""
+import numpy as np
+import unittest
+
+from selene_sdk.predict._common import get_reverse_complement_encoding
+from selene_sdk.sequences import Genome
+
+
+class TestReverseComplement(unittest.TestCase):
+
+    def setUp(self):
+        self.example_encoding = np.array(
+            [[0., 0., 0., 1.],
+             [1., 0., 0., 0.],
+             [0., 1., 0., 0.],
+             [0., 0., 1., 0.],
+             [0.25, 0.25, 0.25, 0.25]]
+        )
+
+    def test_rc_encoding_default(self):
+        observed = get_reverse_complement_encoding(
+            self.example_encoding,
+            Genome.BASES_ARR,
+            Genome.COMPLEMENTARY_BASE_DICT)
+        expected = [
+            [0.25, 0.25, 0.25, 0.25],
+            [0., 1., 0., 0.],
+            [0., 0., 1., 0.],
+            [0., 0., 0., 1.],
+            [1., 0., 0., 0.],
+        ]
+        self.assertEqual(observed.tolist(), expected)
+
+    def test_rc_encoding_nonstandard_ordering(self):
+        observed = get_reverse_complement_encoding(
+            self.example_encoding,
+            ['A', 'T', 'G', 'C'],
+            Genome.COMPLEMENTARY_BASE_DICT)
+        expected = [
+            [0.25, 0.25, 0.25, 0.25],
+            [0., 0., 0., 1.],
+            [1., 0., 0., 0.],
+            [0., 1., 0., 0.],
+            [0., 0., 1., 0.],
+        ]
+        self.assertEqual(observed.tolist(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tutorials/regression_mpra_example/regression_train.yml
+++ b/tutorials/regression_mpra_example/regression_train.yml
@@ -41,7 +41,7 @@ train_model: !obj:selene_sdk.TrainModel {
     data_parallel: False,
     logging_verbosity: 2,
     metrics: {
-        r2: !import:sklearn.metrics.r2_score
+        r2: !import sklearn.metrics.r2_score
     }
 }
 output_dir: ./


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
This is a refactoring change - the code originally used to incorporate variant effect prediction for the reverse strand was unwieldy and difficult to debug.

#### What does this implement/fix? Explain your changes.
Everything is applied to the forward sequence first and then we apply reverse complement afterwards. 

#### What testing did you do to verify the changes in this PR?
Ran and compared the outputs for reverse strand variant effect prediction to verify that it still matched.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
