### PR TITLE
Add  `auc_u_test` to `performance_metrics.py`

### DIFF
--- a/selene_sdk/utils/__init__.py
+++ b/selene_sdk/utils/__init__.py
@@ -13,6 +13,7 @@ from .utils import load_model_from_state_dict
 from .performance_metrics import PerformanceMetrics
 from .performance_metrics import visualize_roc_curves
 from .performance_metrics import visualize_precision_recall_curves
+from .performance_metrics import auc_u_test
 from .config import load
 from .config import load_path
 from .config import instantiate

--- a/selene_sdk/utils/performance_metrics.py
+++ b/selene_sdk/utils/performance_metrics.py
@@ -249,20 +249,26 @@ def get_feature_specific_scores(data, get_feature_from_index_fn):
 
 def auc_u_test(labels, predictions):
 
-    """ Outputs the area under the the ROC curve associated with a certain 
+    """
+    Outputs the area under the the ROC curve associated with a certain 
     set of labels and the predictions given by the training model.
+    Computed from the U statistic.
 
     Parameters
     ----------
     labels: numpy.ndarray
-    Known labels of values predicted by model.
-
+        Known labels of values predicted by model.
+        Must be one dimensional.
     predictions: numpy.ndarray
-    Value predicted by user model
+        Value predicted by user model
+        Must be one dimensional, with matching
+        dimension to `labels`
 
-    Returns:
-    numpy.float64
-    AUC value of given label, prediction pairs  
+    Returns
+    -------
+    float64
+        AUC value of given label, prediction pairs  
+   
     """
     len_pos = int(np.sum(labels))
     len_neg = len(labels) - len_pos
@@ -270,6 +276,7 @@ def auc_u_test(labels, predictions):
     u_value = rank_sum - (len_pos * (len_pos + 1)) / 2
     auc = u_value / (len_pos * len_neg)
     return auc
+
 
 class PerformanceMetrics(object):
     """

--- a/selene_sdk/utils/performance_metrics.py
+++ b/selene_sdk/utils/performance_metrics.py
@@ -13,6 +13,7 @@ from sklearn.metrics import roc_auc_score
 from sklearn.metrics import roc_curve
 from scipy.stats import rankdata
 
+
 logger = logging.getLogger("selene")
 
 
@@ -248,7 +249,6 @@ def get_feature_specific_scores(data, get_feature_from_index_fn):
 
 
 def auc_u_test(labels, predictions):
-
     """
     Outputs the area under the the ROC curve associated with a certain 
     set of labels and the predictions given by the training model.
@@ -257,16 +257,14 @@ def auc_u_test(labels, predictions):
     Parameters
     ----------
     labels: numpy.ndarray
-        Known labels of values predicted by model.
-        Must be one dimensional.
+        Known labels of values predicted by model. Must be one dimensional.
     predictions: numpy.ndarray
-        Value predicted by user model
-        Must be one dimensional, with matching
+        Value predicted by user model. Must be one dimensional, with matching
         dimension to `labels`
 
     Returns
     -------
-    float64
+    float
         AUC value of given label, prediction pairs  
    
     """

--- a/selene_sdk/utils/performance_metrics.py
+++ b/selene_sdk/utils/performance_metrics.py
@@ -11,7 +11,7 @@ from sklearn.metrics import average_precision_score
 from sklearn.metrics import precision_recall_curve
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import roc_curve
-
+from scipy.stats import rankdata
 
 logger = logging.getLogger("selene")
 
@@ -246,6 +246,30 @@ def get_feature_specific_scores(data, get_feature_from_index_fn):
             feature_score_dict[feature] = None
     return feature_score_dict
 
+
+def auc_u_test(labels, predictions):
+
+    """ Outputs the area under the the ROC curve associated with a certain 
+    set of labels and the predictions given by the training model.
+
+    Parameters
+    ----------
+    labels: numpy.ndarray
+    Known labels of values predicted by model.
+
+    predictions: numpy.ndarray
+    Value predicted by user model
+
+    Returns:
+    numpy.float64
+    AUC value of given label, prediction pairs  
+    """
+    len_pos = int(np.sum(labels))
+    len_neg = len(labels) - len_pos
+    rank_sum = np.sum(rankdata(predictions)[labels == 1])
+    u_value = rank_sum - (len_pos * (len_pos + 1)) / 2
+    auc = u_value / (len_pos * len_neg)
+    return auc
 
 class PerformanceMetrics(object):
     """


### PR DESCRIPTION
**Reference Issues/PRs**
Fixes https://github.com/FunctionLab/selene/issues/70. Adds new AUC calculation. The previously used implementation is sklearn's `roc_auc_score`, which is currently offered as the default metric. 

**What does this implement/fix? Explain your changes.**
Offers a faster implementation of the AUC calculation.  Based off of the following: https://blog.revolutionanalytics.com/2017/03/auc-meets-u-stat.html

**What testing did you do to verify the changes in this PR?**
Compared `roc_auc_score`  to `auc_u_test` and confirmed that they calculate the same values up to the same precision. Also timed the methods and confirmed that this new implementation is about 10x faster.


