### PR TITLE
Remove chromosome/scaffold name mangling for bed/vcf files

### DIFF
--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -85,12 +85,13 @@ def read_vcf_file(input_path,
             chrom = str(cols[0])
             if 'CHR' == chrom[:3]:
                 chrom = chrom.replace('CHR', 'chr')
-            elif "chr" not in chrom:
-                chrom = "chr" + chrom
 
             if chrom == "chrMT" and \
                     chrom not in reference_sequence.get_chrs():
                 chrom = "chrM"
+            elif chrom == "MT" and \
+                    chrom not in reference_sequence.get_chrs():
+                chrom = "M"
 
             pos = int(cols[1])
             name = cols[2]

--- a/selene_sdk/predict/_variant_effect_prediction.py
+++ b/selene_sdk/predict/_variant_effect_prediction.py
@@ -62,6 +62,11 @@ def read_vcf_file(input_path,
     """
     variants = []
     na_rows = []
+    check_chr = True
+    for chrom in reference_sequence.get_chrs():
+        if not chrom.startswith("chr"):
+            check_chr = False
+            break
     with open(input_path, 'r') as file_handle:
         lines = file_handle.readlines()
         index = 0
@@ -85,6 +90,8 @@ def read_vcf_file(input_path,
             chrom = str(cols[0])
             if 'CHR' == chrom[:3]:
                 chrom = chrom.replace('CHR', 'chr')
+            elif "chr" not in chrom and check_chr is True:
+                chrom = "chr" + chrom
 
             if chrom == "chrMT" and \
                     chrom not in reference_sequence.get_chrs():

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -298,6 +298,11 @@ class AnalyzeSequences(object):
         sequences = []
         labels = []
         na_rows = []
+        check_chr = True
+        for chrom in reference_sequence.get_chrs():
+            if not chrom.startswith("chr"):
+                check_chr = False
+                break
         with open(input_path, 'r') as read_handle:
             for i, line in enumerate(read_handle):
                 cols = line.strip().split('\t')
@@ -310,6 +315,8 @@ class AnalyzeSequences(object):
                 strand = '.'
                 if isinstance(strand_index, int) and len(cols) > strand_index:
                     strand = cols[strand_index]
+                if 'chr' not in chrom and check_chr is True:
+                    chrom = "chr{0}".format(chrom)
                 if not str.isdigit(start) or not str.isdigit(end) \
                         or chrom not in self.reference_sequence.genome:
                     na_rows.append(line)

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -310,8 +310,6 @@ class AnalyzeSequences(object):
                 strand = '.'
                 if isinstance(strand_index, int) and len(cols) > strand_index:
                     strand = cols[strand_index]
-                if 'chr' not in chrom:
-                    chrom = 'chr{0}'.format(chrom)
                 if not str.isdigit(start) or not str.isdigit(end) \
                         or chrom not in self.reference_sequence.genome:
                     na_rows.append(line)


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this implement/fix? Explain your changes.
Selene should no longer automatically add "chr" to the start of the chromosome/scaffold name for every record in a bed/vcf file. 

#### What testing did you do to verify the changes in this PR?
Verified that specified changes did not cause existing prediction and VEP examples to fail.