### PR TITLE
Add raw sequence predict

### DIFF
--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -536,8 +536,9 @@ class AnalyzeSequences(object):
         input : str
             A single sequence, or a path to the FASTA or BED file input.
         output_dir : str, optional
-            Output directory to write the model predictions. If this is left
-            blank a raw sequence input will be assumed.
+            Default is None. Output directory to write the model predictions.
+            If this is left blank a raw sequence input will be assumed, though
+            an output directory is required for FASTA and BED inputs.
         output_format : {'tsv', 'hdf5'}, optional
             Default is 'tsv'. Choose whether to save TSV or HDF5 output files.
             TSV is easier to access (i.e. open with text editor/Excel) and
@@ -1138,8 +1139,7 @@ class AnalyzeSequences(object):
         for r in reporters:
             r.write_to_file()
 
-    def _pad_or_truncate_sequence(self, input_seq):
-        sequence = input_seq
+    def _pad_or_truncate_sequence(self, sequence):
         if len(sequence) < self.sequence_length:
             sequence = _pad_sequence(
                 sequence,

--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -531,19 +531,21 @@ class AnalyzeSequences(object):
 
 
     def get_predictions(self,
-                        input_path,
-                        output_dir,
+                        input,
+                        output_dir=None,
                         output_format="tsv",
                         strand_index=None):
         """
-        Get model predictions for sequences specified in a FASTA or BED file.
+        Get model predictions for sequences specified as a raw sequence,
+        FASTA, or BED file.
 
         Parameters
         ----------
-        input_path : str
-            Input path to the FASTA or BED file.
-        output_dir : str
-            Output directory to write the model predictions.
+        input : str
+            A single sequence, or a path to the FASTA or BED file input.
+        output_dir : str, optional
+            Output directory to write the model predictions. If this is left
+            blank a raw sequence input will be assumed.
         output_format : {'tsv', 'hdf5'}, optional
             Default is 'tsv'. Choose whether to save TSV or HDF5 output files.
             TSV is easier to access (i.e. open with text editor/Excel) and
@@ -583,15 +585,29 @@ class AnalyzeSequences(object):
             or .tsv file will mark this sequence or region as `contains_unk = True`.
 
         """
-        if input_path.endswith('.fa') or input_path.endswith('.fasta'):
+        if output_dir is None:
+            sequence = input
+            if len(input) < self.sequence_length:
+                sequence = _pad_sequence(input,
+                                             self.sequence_length,
+                                             self.reference_sequence.UNK_BASE)
+            elif len(input) > self.sequence_length:
+                sequence = _truncate_sequence(input, self.sequence_length)
+
+            seq_enc = self.reference_sequence.sequence_to_encoding(sequence)
+            seq_enc = np.expand_dims(seq_enc, axis=0)  # add batch size of 1
+            return predict(self.model, seq_enc)
+        elif input.endswith('.fa') or input.endswith('.fasta'):
             self.get_predictions_for_fasta_file(
-                input_path, output_dir, output_format=output_format)
+                input, output_dir, output_format=output_format)
         else:
             self.get_predictions_for_bed_file(
-                input_path,
+                input,
                 output_dir,
                 output_format=output_format,
                 strand_index=strand_index)
+
+        return None
 
     def in_silico_mutagenesis_predict(self,
                                       sequence,

--- a/tutorials/analyzing_mutations_with_trained_models/analyzing_mutations_with_trained_models.ipynb
+++ b/tutorials/analyzing_mutations_with_trained_models/analyzing_mutations_with_trained_models.ipynb
@@ -17,6 +17,8 @@
     "\n",
     "Download the compressed data from [here](https://zenodo.org/record/1319784): \n",
     "\n",
+    "**Note: The tutorials and manuscript examples have been run on Selene versions 0.1.3 through 0.2.0, and PyTorch version 0.4.1. Models associated with the manuscript can only be run with PyTorch 0.4.1, as PyTorch models are not forward-compatible.**\n",
+    "\n",
     "```sh\n",
     "wget https://zenodo.org/record/2206957/files/selene_analyzing_mutations_tutorial.tar.gz\n",
     "```\n",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

This PR modifies the `AnalyzeSequences` member method `get_predictions` to enable the submission of python strings as a raw sequence to retrieve predictions as Python object. 

Previously predictions for sequences could only be requested using FASTA files.

#### What testing did you do to verify the changes in this PR?

I successfully retrieved an array of predictions using both a raw sequence of 1000 length, and using the same sequence formatted as a FASTA file. The resulting predictions were the same in both cases.