### PR TITLE
Add missing cuda parameter to predict call

### DIFF
--- a/selene_sdk/predict/model_predict.py
+++ b/selene_sdk/predict/model_predict.py
@@ -582,7 +582,7 @@ class AnalyzeSequences(object):
             sequence = self._pad_or_truncate_sequence(input)
             seq_enc = self.reference_sequence.sequence_to_encoding(sequence)
             seq_enc = np.expand_dims(seq_enc, axis=0)  # add batch size of 1
-            return predict(self.model, seq_enc)
+            return predict(self.model, seq_enc, use_cuda=self.use_cuda)
         elif input.endswith('.fa') or input.endswith('.fasta'):
             self.get_predictions_for_fasta_file(
                 input, output_dir, output_format=output_format)


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Call to `predict` does not specify whether to use cuda or not, therefore systems which use cuda will not be able to use this feature since the default is `False`.

#### What testing did you do to verify the changes in this PR?

It's a single parameter which I manually set on my dev server.  It uses the same property as the other  `predict` calls in the `AnalyzeSequences` class.