### PR TITLE
Sample without replacement in RandomPositionSampler

### DIFF
--- a/selene_sdk/samplers/random_positions_sampler.py
+++ b/selene_sdk/samplers/random_positions_sampler.py
@@ -7,7 +7,6 @@ We would like to generalize this to `selene_sdk.sequences.Sequence` if possible.
 from collections import namedtuple
 import logging
 import random
-import time
 
 import numpy as np
 
@@ -128,7 +127,6 @@ class RandomPositionsSampler(OnlineSampler):
         The current mode that the sampler is running in. Must be one of
         the modes listed in `modes`.
     """
-
     def __init__(self,
                  reference_sequence,
                  target_path,
@@ -386,8 +384,8 @@ class RandomPositionsSampler(OnlineSampler):
         Parameters
         ----------
         batch_size : int, optional
-        Default is 1. The number of examples to include in the
-        mini-batch.
+            Default is 1. The number of examples to include in the
+            mini-batch.
 
         Returns
         -------

--- a/selene_sdk/samplers/random_positions_sampler.py
+++ b/selene_sdk/samplers/random_positions_sampler.py
@@ -235,15 +235,15 @@ class RandomPositionsSampler(OnlineSampler):
         test = np.arange(total, dtype=np.int64)
         jump = 250000000
         num_steps = int(total / jump)
-        # start = 0
-        # for i in range(num_steps):
-        #     np.random.shuffle(test[start : start + jump])
-        #     start = start + jump
+        start = 0
+        for i in range(num_steps):
+            np.random.shuffle(test[start : start + jump])
+            start = start + jump
 
-        # start = int(jump / 2)
-        # for i in range(num_steps - 1):
-        #     np.random.shuffle(test[start : start + jump])
-        #     start = start + jump
+        start = int(jump / 2)
+        for i in range(num_steps - 1):
+            np.random.shuffle(test[start : start + jump])
+            start = start + jump
 
         return test
         # rename
@@ -286,15 +286,6 @@ class RandomPositionsSampler(OnlineSampler):
             # get_N = _assign_samples_per_mode(training_prop_N, "train", start, self._N_train, genome_positions_arr)
             self._N_train -= get_N
 
-    # def printAll(self):
-    #     print("test")
-    #     print(self._partition_ixs["test"])
-    #
-    #     print("validate")
-    #     print(self._partition_ixs["validate"])
-    #
-    #     print("train")
-    #     print(self._partition_ixs["train"])
 
     # def _partition_by_chrom(self):
     #     return
@@ -393,8 +384,6 @@ class RandomPositionsSampler(OnlineSampler):
 
     def _sample(self):
         # @ Kathy, where do we set the partition for a particular sample?
-        # TODO: Overflow errors occured when using this random indexing
-        # Overflow should not occur with int64.
         # random_index = np.random.randint(0, len(self._partition_ixs[self.mode]))
         sample_index = self._partition_ixs[self.mode][0]
         chrom, pos = self._pair_from_index(sample_index)
@@ -429,13 +418,7 @@ class RandomPositionsSampler(OnlineSampler):
         targets = np.zeros((batch_size, self.n_features))
         n_samples_drawn = 0
         while n_samples_drawn < batch_size:
-            print("Samples: ")
-            print(n_samples_drawn)
             chrom, position = self._sample()
-            print("Chrom: ")
-            print(chrom)
-            print("Position: ")
-            print(position)
             retrieve_output = self._retrieve(chrom, position)
             if not retrieve_output:
                 continue

--- a/selene_sdk/samplers/random_positions_sampler.py
+++ b/selene_sdk/samplers/random_positions_sampler.py
@@ -335,6 +335,7 @@ class RandomPositionsSampler(OnlineSampler):
             self.tot_sample = np.append(self.tot_sample, curr_sample)
 
         self.sample_init = True
+        
 
 # Returns (chrom, poition) pair corresponding to index in the genome array.
     def _pair_from_index(self, index):

--- a/selene_sdk/samplers/random_positions_sampler_original.py
+++ b/selene_sdk/samplers/random_positions_sampler_original.py
@@ -1,11 +1,9 @@
 """
 This module provides the RandomPositionsSampler class.
-
 TODO: Currently, only works with sequences from `selene_sdk.sequences.Genome`.
 We would like to generalize this to `selene_sdk.sequences.Sequence` if possible.
 """
 from collections import namedtuple
-from collections import defaultdict
 import logging
 import random
 
@@ -22,33 +20,28 @@ SampleIndices = namedtuple(
 """
 A tuple containing the indices for some samples, and a weight to
 allot to each index when randomly drawing from them.
-
 TODO: this is common to both the intervals sampler and the
 random positions sampler. Can we move this to utils or
 somewhere else?
-
 Parameters
 ----------
 indices : list(int)
     The numeric index of each sample.
 weights : list(float)
     The amount of weight assigned to each sample.
-
 Attributes
 ----------
 indices : list(int)
     The numeric index of each sample.
 weights : list(float)
     The amount of weight assigned to each sample.
-
 """
+
 
 class RandomPositionsSampler(OnlineSampler):
     """This sampler randomly selects a position in the genome and queries for
     a sequence centered at that position for input to the model.
-
     TODO: generalize to selene_sdk.sequences.Sequence?
-
     Parameters
     ----------
     reference_sequence : selene_sdk.sequences.Genome
@@ -58,12 +51,6 @@ class RandomPositionsSampler(OnlineSampler):
         coordinates mapped to the genomic features we want to predict.
     features : list(str)
         List of distinct features that we aim to predict.
-    train_size : int
-        Total sample size for train set.
-    validation_size : int
-        Total sample size of validation set.
-    test_size : int
-        Total sample size of test set.
     seed : int, optional
         Default is 436. Sets the random seed for sampling.
     validation_holdout : list(str) or float, optional
@@ -96,7 +83,6 @@ class RandomPositionsSampler(OnlineSampler):
         a non-empty list, `output_dir` must be specified. If
         the path in `output_dir` does not exist it will be created
         automatically.
-
     Attributes
     ----------
     reference_sequence : selene_sdk.sequences.Genome
@@ -133,9 +119,6 @@ class RandomPositionsSampler(OnlineSampler):
                  reference_sequence,
                  target_path,
                  features,
-                 train_size,
-                 validation_size,
-                 test_size,
                  seed=436,
                  validation_holdout=['chr6', 'chr7'],
                  test_holdout=['chr8', 'chr9'],
@@ -159,178 +142,86 @@ class RandomPositionsSampler(OnlineSampler):
             save_datasets=save_datasets,
             output_dir=output_dir)
 
+        self._sample_from_mode = {}
+        self._randcache = {}
+        for mode in self.modes:
+            self._sample_from_mode[mode] = None
+            self._randcache[mode] = {"cache_indices": None, "sample_next": 0}
+
         self.sample_from_intervals = []
         self.interval_lengths = []
 
-        self._num_chroms = 0
-        self._genome_n_bases = 0
-        for chrom, len_chrom in self.reference_sequence.get_chr_lens():
-            self._num_chroms += 1
-            self._genome_n_bases += len_chrom
-
-        self._validation_holdout = validation_holdout
-        self._N_validation = validation_size
-
-        if test_holdout:
-            self._test_holdout = test_holdout
-            self._N_test = test_size
-
-        self._N_train = train_size
-
-        self._partition_ixs = {"Train": np.zeros(self._N_train, dtype=np.int64),
-                                "Validate": np.zeros(self._N_validation, dtype=np.int64),
-                                "Test": np.zeros(self._N_test, dtype=np.int64)}
-
-        # Information about each chromosome, "Total" holds the chrom names
-        # "Starts" holds the start indices in a theoretical flat array of all
-        # chromosomes, "Ends" holds the end indices.
-        self.chroms_info = {"Total": [],
-                            "Starts": np.zeros(self._num_chroms),
-                            "Ends": np.zeros(self._num_chroms)}
-
-        if isinstance(validation_holdout, float):
-            self._partition_by_proportion()
-        elif isinstance(validation_holdout):
-            self._partition_by_chromosome()
-
-    # Setup `self.chroms`, `self.chroms_starts`, `self.chroms_ends`, `self.genome_length`
-    def _init_chroms(self):
-        tot_len = 0
-        counter = 0
-        for chrom, len_chrom in self.reference_sequence.get_chr_lens():
-            self.chroms_info["Total"].append(chrom)
-            self.chroms_info["Starts"][counter] = tot_len
-            self.chroms_info["Ends"][counter] = tot_len + len_chrom
-            tot_len += len_chrom
-            counter += 1
-
-    # Compute the number of elements in the genome array that belong to
-    # each mode, by proportion
-
-    # Edit to be used by chromosome code as well.
-    def _assign_proportions(self):
-        if self.test_holdout:
-            test_prop_N = self._genome_n_bases * self._test_holdout
-            validation_prop_N = self._genome_n_bases * self._validation_holdout
-            training_prop_N = \
-                self._genome_n_bases * (1 - self._test_holdout - self._validation_holdout)
-            return int(test_prop_N), int(validation_prop_N), int(training_prop_N)
+        if self._holdout_type == "chromosome":
+            self._partition_genome_by_chromosome()
         else:
-            validation_prop_N = self._genome_n_bases * self._validation_holdout
-            training_prop_N = self._genome_n_bases * (1 - _validation_holdout)
-            return int(validation_prop_N), int(training_prop_N)
+            self._partition_genome_by_proportion()
 
-    # def _assign_samples_per_mode(self, prop_N, mode, start, sample_size, genome_positions_arr):
-    #     get_N = min(prop_N, sample_size)
-    #     self._partition_ixs[mode] = genome_positions_arr[start:start + get_N]
-    #     return get_N
+        for mode in self.modes:
+            self._update_randcache(mode=mode)
 
+    def _partition_genome_by_proportion(self):
+        for chrom, len_chrom in self.reference_sequence.get_chr_lens():
+            self.sample_from_intervals.append(
+                (chrom,
+                 self.sequence_length,
+                 len_chrom - self.sequence_length))
+            self.interval_lengths.append(len_chrom)
+        n_intervals = len(self.sample_from_intervals)
 
-    def _partition_by_proportion(self):
-        self._init_chroms()
-        self._assign_samples() # can these be expanded to be used by partition by chrom?
+        select_indices = list(range(n_intervals))
+        np.random.shuffle(select_indices)
+        n_indices_validate = int(n_intervals * self.validation_holdout)
+        val_indices, val_weights = get_indices_and_probabilities(
+            self.interval_lengths, select_indices[:n_indices_validate])
+        self._sample_from_mode["validate"] = SampleIndices(
+            val_indices, val_weights)
 
-    def _psuedoshuffle(self):
-        total = self._genome_n_bases
-        test = np.arange(total, dtype=np.int64)
-        jump = 250000000
-        num_steps = int(total / jump)
-        # start = 0
-        # for i in range(num_steps):
-        #     np.random.shuffle(test[start : start + jump])
-        #     start = start + jump
-
-        # start = int(jump / 2)
-        # for i in range(num_steps - 1):
-        #     np.random.shuffle(test[start : start + jump])
-        #     start = start + jump
-
-        return test
-        # rename
-
-    # Order: test, validate, train
-    # Make sure this matches chromosome implementation
-    def _assign_samples(self):
-        genome_positions_arr = self._psuedoshuffle()
-        start = 0
         if self.test_holdout:
-            test_prop_N, validation_prop_N, training_prop_N = self._assign_proportions()
-            N_test = self._N_test
-            while N_test:
-                get_N = min(test_prop_N, N_test)
-                self._partition_ixs["test"] = genome_positions_arr[start : start + get_N]
-                # get_N = self._assign_samples_per_mode(test_prop_N, "test", start, self._N_test, genome_positions_arr)
-                N_test -= get_N
-                if N_test :
-                    start = start + get_N
+            n_indices_test = int(n_intervals * self.test_holdout)
+            test_indices_end = n_indices_test + n_indices_validate
+            test_indices, test_weights = get_indices_and_probabilities(
+                self.interval_lengths,
+                select_indices[n_indices_validate:test_indices_end])
+            self._sample_from_mode["test"] = SampleIndices(
+                test_indices, test_weights)
 
-            start = start + get_N
-
+            tr_indices, tr_weights = get_indices_and_probabilities(
+                self.interval_lengths, select_indices[test_indices_end:])
+            self._sample_from_mode["train"] = SampleIndices(
+                tr_indices, tr_weights)
         else:
-            validation_prop_N, training_prop_N = _assign_proportions()
+            tr_indices, tr_weights = get_indices_and_probabilities(
+                self.interval_lengths, select_indices[n_indices_validate:])
+            self._sample_from_mode["train"] = SampleIndices(
+                tr_indices, tr_weights)
 
-        N_validation = self._N_validation
-        while N_validation:
-            get_N = min(validation_prop_N, N_validation)
-            self._partition_ixs["validate"] = genome_positions_arr[start:start + get_N]
-            # get_N = _assign_samples_per_mode(validation_prop_N, "validation", start, self._N_validation, genome_positions_arr)
-            N_validation -= get_N # I dont think we can alter an int like this in a function bc its pass by copy
-            if N_validation:
-                start = start + get_N
+    def _partition_genome_by_chromosome(self):
+        for mode in self.modes:
+            self._sample_from_mode[mode] = SampleIndices([], [])
+        for index, (chrom, len_chrom) in enumerate(self.reference_sequence.get_chr_lens()):
+            if chrom in self.validation_holdout:
+                self._sample_from_mode["validate"].indices.append(
+                    index)
+            elif self.test_holdout and chrom in self.test_holdout:
+                self._sample_from_mode["test"].indices.append(
+                    index)
+            else:
+                self._sample_from_mode["train"].indices.append(
+                    index)
 
+            self.sample_from_intervals.append(
+                (chrom,
+                 self.sequence_length,
+                 len_chrom - self.sequence_length))
+            self.interval_lengths.append(len_chrom - 2 * self.sequence_length)
 
-        start = start + get_N
-        while self._N_train:
-            get_N = min(training_prop_N, self._N_train)
-            self._partition_ixs["train"] = genome_positions_arr[start:start + get_N]
-            # get_N = _assign_samples_per_mode(training_prop_N, "train", start, self._N_train, genome_positions_arr)
-            self._N_train -= get_N
-
-    # def printAll(self):
-    #     print("test")
-    #     print(self._partition_ixs["test"])
-    #
-    #     print("validate")
-    #     print(self._partition_ixs["validate"])
-    #
-    #     print("train")
-    #     print(self._partition_ixs["train"])
-
-    # def _partition_by_chrom(self):
-    #     return
-    #
-    #     genome_arr = np.arange(self._genome_n_bases)
-    #     # to keep this SIMPLE, you create the chromosome to position map based on what chromosomes
-    #     # the user specifies as holdouts!
-    #     # so validation is always after training, test chroms always after validation
-    #     tot_len = 0
-    #     train_counter = 0
-    #     validation_counter = self._N_train
-    #     test_counter = self._N_train + self._N_validation
-    #     genome_positions_arr = np.zeros(self._genome_n_bases)
-    #
-    #     for chrom, len in self.genome.get_chr_lens():
-    #
-    #         if chrom in self.validation_holdout:
-    #             genome_positions_arr[validation_counter  : validation_counter  + len] = np.arange(tot_len, tot_len + len)
-    #         elif chrom in self.test_holdout:
-    #             genome_positions_arr[test_counter : test_counter + len] = np.arange(tot_len, tot_len + len)
-    #         else:
-    #             genome_positions_arr[train_counter  : train_counter  + len] = np.arange(tot_len, tot_len + len)
-    #
-    #         for mode in self.modes:
-    #             # Shuffle each partitition individually
-    #             np.shuffle(genome_positions_arr[0:self._N_train])
-    #             np.shuffle(genome_positions_arr[self._N_train:self._N_train + self._N_validation])
-    #             np.shuffle(genome_positions_arr[self._N_train + self._N_validation:])
-    #
-    #             # what would be interval lengths here???
-    #             sample_indices = self._partition_ixs[mode].indices
-    #             indices, weights = get_indices_and_probabilities(
-    #                 self.interval_lengths, sample_indices)
-    #             self._sample_from_mode[mode] = \
-    #                 self._sample_from_mode[mode]._replace(
-    #                     indices=indices, weights=weights)
+        for mode in self.modes:
+            sample_indices = self._sample_from_mode[mode].indices
+            indices, weights = get_indices_and_probabilities(
+                self.interval_lengths, sample_indices)
+            self._sample_from_mode[mode] = \
+                self._sample_from_mode[mode]._replace(
+                    indices=indices, weights=weights)
 
     def _retrieve(self, chrom, position):
         bin_start = position - self._start_radius
@@ -382,36 +273,25 @@ class RandomPositionsSampler(OnlineSampler):
                 self.save_dataset_to_file(self.mode)
         return (retrieved_seq, retrieved_targets)
 
-    # Returns (chrom, poition) pair corresponding to index in the genome array.
-    def _pair_from_index(self, index):
-        curr_index = 0
-        all = np.where(self.chroms_info["Ends"] >= index)
-        min = all[0][0]
-        chrom = self.chroms_info["Total"][min]
-        pos = int(index - self.chroms_info["Starts"][min])
-        return chrom, pos
+    def _update_randcache(self, mode=None):
+        if not mode:
+            mode = self.mode
+        self._randcache[mode]["cache_indices"] = np.random.choice(
+            self._sample_from_mode[mode].indices,
+            size=200000,
+            replace=True,
+            p=self._sample_from_mode[mode].weights)
+        self._randcache[mode]["sample_next"] = 0
 
-    def _sample(self):
-        # @ Kathy, where do we set the partition for a particular sample?
-        # TODO: Overflow errors occured when using this random indexing
-        # Overflow should not occur with int64.
-        # random_index = np.random.randint(0, len(self._partition_ixs[self.mode]))
-        sample_index = self._partition_ixs[self.mode][0]
-        chrom, pos = self._pair_from_index(sample_index)
-        np.delete(self._partition_ixs[self.mode], 0)
-        return chrom, pos
-
-    def sample(self, batch_size):
+    def sample(self, batch_size=1):
         """
         Randomly draws a mini-batch of examples and their corresponding
         labels.
-
         Parameters
         ----------
         batch_size : int, optional
             Default is 1. The number of examples to include in the
             mini-batch.
-
         Returns
         -------
         sequences, targets : tuple(numpy.ndarray, numpy.ndarray)
@@ -423,19 +303,24 @@ class RandomPositionsSampler(OnlineSampler):
             :math:`N` is the size of the sequence type's alphabet.
             The shape of `targets` will be :math:`B \\times F`,
             where :math:`F` is the number of features.
-
         """
         sequences = np.zeros((batch_size, self.sequence_length, 4))
         targets = np.zeros((batch_size, self.n_features))
         n_samples_drawn = 0
         while n_samples_drawn < batch_size:
-            print("Samples: ")
-            print(n_samples_drawn)
-            chrom, position = self._sample()
-            print("Chrom: ")
-            print(chrom)
-            print("Position: ")
-            print(position)
+            sample_index = self._randcache[self.mode]["sample_next"]
+            if sample_index == len(self._randcache[self.mode]["cache_indices"]):
+                self._update_randcache()
+                sample_index = 0
+
+            rand_interval_index = \
+                self._randcache[self.mode]["cache_indices"][sample_index]
+            self._randcache[self.mode]["sample_next"] += 1
+
+            chrom, cstart, cend = \
+                self.sample_from_intervals[rand_interval_index]
+            position = np.random.randint(cstart, cend)
+
             retrieve_output = self._retrieve(chrom, position)
             if not retrieve_output:
                 continue


### PR DESCRIPTION
**Reference Issues/PRs**

Recreate class implementation. Previous implementation always samples with replacement. This new implementation samples without replacement, unless the user’s sample_size exceeds the partition they seek to sample from in each mode, in which case, we are constrained to have some duplicates.

This PR is a work in progress. Investigating why some sample items are not being retrieved properly. TODO: add check to make sure elements that cannot be retrieved are not added to the sample set. 

**What does this implement/fix? Explain your changes.**

This implementation has a time constraint up front, where the samples for each mode are predetermined based on the user specified sample size for each mode. This is done by shuffling (either individual chromosomes, or the entire genome) and then taking the first N for each mode. 

Subsequently, sampling is quick, in that samples items are simply popped off a stack-like data structure. While there is a space constraint in holding the positions, this constraint dwindles as samples are taken, since the items are removed as they are chosen.

The long term space constraint will be fully determined by the user specification of sample size for each mode. This can be made clear up front, to ensure the user is able to accommodate this constraint. 

As an additional note, the previous implementation of “sampling by proportion” has been updated. Previously, proportions were separated by chromosome. Instead, this implementation partitions proportions of the entire genome, so that each mode can have samples from overlapping chromosome. However, to reduce time, only a psuedoshuffle is performed on 500mil base pair chunks (may have to make this a function of the whole genome size). This psuedoshuffle is still being designed.

**What testing did you do to verify the changes in this PR?**

- Timing tests were performed. We found that shuffling blew up with increases size (for example: from around 30-60 seconds for a 500 million base pair chunk to over two minutes for a 750 million chunk). 
- Shuffling the six 500 million chunks of a 3 billion base pair genome took around 6 minutes.
- The original implementation was added separated to perform side by side testing.
- Checked that data structures (parallel, chroms_info) were constructed as expected