### PR TITLE
Fix wrong filename

### DIFF
--- a/manuscript/case2/1_train_with_online_sampler/data/process_data.sh
+++ b/manuscript/case2/1_train_with_online_sampler/data/process_data.sh
@@ -19,8 +19,8 @@ tabix -p bed sorted_deepsea_data.bed.gz
 
 sort -o distinct_features.txt distinct_features.txt
 
-python create_TF_intervals.py distinct_features.txt \
-                              sorted_deepsea_data.bed \
-                              TF_intervals_unmerged.txt
+python create_TF_intervals_file.py distinct_features.txt \
+                                   sorted_deepsea_data.bed \
+                                   TF_intervals_unmerged.txt
 
 bedtools merge -i TF_intervals_unmerged.txt > TF_intervals.txt


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
The folder contains `create_TF_intervals_file.py`, though the script currently points to `create_TF_intervals.py`.


#### What testing did you do to verify the changes in this PR?
Ran the script locally

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
