### PR TITLE
Delete autograd.Variable as it is deprecated since pytorch v0.4.1

### DIFF
--- a/selene_sdk/evaluate_model.py
+++ b/selene_sdk/evaluate_model.py
@@ -8,7 +8,6 @@ import warnings
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 
 from .sequences import Genome
 from .utils import _is_lua_trained_model
@@ -217,9 +216,6 @@ class EvaluateModel(object):
                 inputs = inputs.cuda()
                 targets = targets.cuda()
             with torch.no_grad():
-                inputs = Variable(inputs)
-                targets = Variable(targets)
-
                 predictions = None
                 if _is_lua_trained_model(self.model):
                     predictions = self.model.forward(

--- a/selene_sdk/predict/_common.py
+++ b/selene_sdk/predict/_common.py
@@ -5,7 +5,6 @@ import math
 
 import numpy as np
 import torch
-from torch.autograd import Variable
 
 from ..utils import _is_lua_trained_model
 
@@ -90,8 +89,6 @@ def predict(model, batch_sequences, use_cuda=False):
     if use_cuda:
         inputs = inputs.cuda()
     with torch.no_grad():
-        inputs = Variable(inputs)
-
         if _is_lua_trained_model(model):
             outputs = model.forward(
                 inputs.transpose(1, 2).contiguous().unsqueeze_(2))

--- a/selene_sdk/train_model.py
+++ b/selene_sdk/train_model.py
@@ -11,7 +11,6 @@ from time import time
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.autograd import Variable
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 from sklearn.metrics import roc_auc_score
 from sklearn.metrics import average_precision_score
@@ -458,9 +457,6 @@ class TrainModel(object):
             inputs = inputs.cuda()
             targets = targets.cuda()
 
-        inputs = Variable(inputs)
-        targets = Variable(targets)
-
         predictions = self.model(inputs.transpose(1, 2))
         loss = self.criterion(predictions, targets)
 
@@ -500,9 +496,6 @@ class TrainModel(object):
                 targets = targets.cuda()
 
             with torch.no_grad():
-                inputs = Variable(inputs)
-                targets = Variable(targets)
-
                 predictions = self.model(inputs.transpose(1, 2))
                 loss = self.criterion(predictions, targets)
 
@@ -622,4 +615,3 @@ class TrainModel(object):
             best_filepath = os.path.join(self.output_dir, "best_model")
             shutil.copyfile("{0}.pth.tar".format(cp_filepath),
                             "{0}.pth.tar".format(best_filepath))
-


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
`Variable(tensor)` just returns a `Tensor` since v0.4.1.
See https://pytorch.org/docs/0.4.1/autograd.html?highlight=autograd#variable-deprecated

selene-cpu.yml points to pytorch 0.4.1
selene-gpu*.yml points to pytorch 1.0.1

#### What testing did you do to verify the changes in this PR?
Ran train script and training did work fine.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
