### PR TITLE
Fix a typo and documentation

### DIFF
--- a/selene_sdk/samplers/intervals_sampler.py
+++ b/selene_sdk/samplers/intervals_sampler.py
@@ -305,7 +305,7 @@ class IntervalsSampler(OnlineSampler):
         Returns
         -------
         retrieved_seq, retrieved_targets : \
-        tuple(numpy.ndarray, list(numpy.ndarray))
+        tuple(numpy.ndarray, numpy.ndarray)
             A tuple containing the numeric representation of the
             sequence centered at the query position, as well as a list
             of samples within this region that met the filtering

--- a/selene_sdk/targets/genomic_features.py
+++ b/selene_sdk/targets/genomic_features.py
@@ -336,12 +336,7 @@ class GenomicFeatures(Target):
 
     def get_feature_data(self, chrom, start, end):
         """
-        For a sequence of length :math:`L = end - start`, return the
-        features' one-hot encoding corresponding to that region. For
-        instance, for `n_features`, each position in that sequence will
-        have a binary vector specifying whether the genomic feature's
-        coordinates overlap with that position.
-        @TODO: Clarify with an example, as this is hard to read right now.
+        Computes which features overlap with the given region.
 
         Parameters
         ----------
@@ -355,21 +350,23 @@ class GenomicFeatures(Target):
         Returns
         -------
         numpy.ndarray
-            :math:`L \\times N` array, where :math:`L = end - start`
-            and :math:`N =` `self.n_features`. Note that if we catch a
-            `tabix.TabixError`, we assume the error was the result of
-            there being no features present in the queried region and
-            return a `numpy.ndarray` of zeros.
+            A target vector of size `self.n_features` where the `i`th
+            position is equal to one if the `i`th feature is positive,
+            and zero otherwise.
+
+            NOTE: If we catch a `tabix.TabixError`, we assume the error was
+            the result of there being no features present in the queried region
+            and return a `numpy.ndarray` of zeros.
 
         """
         if self._feature_thresholds_vec is None:
-            features = np.zeros((end - start))
+            features = np.zeros(self.n_features)
             rows = self._query_tabix(chrom, start, end)
             if not rows:
                 return features
             for r in rows:
                 feature = r[3]
-                ix = self.feature_index_map[feature]
+                ix = self.feature_index_dict[feature]
                 features[ix] = 1
             return features
         return _get_feature_data(

--- a/selene_sdk/targets/tests/test_genomic_features.py
+++ b/selene_sdk/targets/tests/test_genomic_features.py
@@ -248,5 +248,48 @@ class TestGenomicFeatures(unittest.TestCase):
             query_features._feature_thresholds_vec.tolist(),
             [0.40, 0.50, 0.50, 0.30, 0.50, 0.50])
 
+    def test_GenomicFeatures_no_thresholds__get_feature_data(self):
+        data_path = os.path.join(
+            "selene_sdk", "targets", "tests",
+            "files", "sorted_aggregate.bed.gz")
+        query_features = GenomicFeatures(
+            data_path, self.features, feature_thresholds=None)
+
+        expected_feature_data = np.zeros(self.n_features)
+        expected_feature_data[self.feature_index_map['CTCF']] = 1.
+
+        # NOTE: "1	16110	16390	CTCF" is the first line in the test data.
+        actual_feature_data = query_features.get_feature_data('1', 16110, 16390)
+
+        np.testing.assert_array_almost_equal(
+            actual_feature_data,
+            expected_feature_data
+        )
+
+    def test_GenomicFeatures_0_5_threshold__get_feature_data(self):
+        data_path = os.path.join(
+            "selene_sdk", "targets", "tests",
+            "files", "sorted_aggregate.bed.gz")
+        query_features = GenomicFeatures(
+            data_path, self.features, feature_thresholds=0.5)
+
+        # NOTE: "1	16110	16390	CTCF" is the first line in the test data.
+
+        # Overlap is less than a threshold:
+        np.testing.assert_array_almost_equal(
+            query_features.get_feature_data('1', 16000, 17000),
+            np.zeros(self.n_features)
+        )
+
+        # Overlap is greater than a threshold:
+        expected_feature_data = np.zeros(self.n_features)
+        expected_feature_data[self.feature_index_map['CTCF']] = 1.
+
+        np.testing.assert_array_almost_equal(
+            query_features.get_feature_data('1', 16000, 16500),
+            expected_feature_data
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
- The dictionary name is wrong.
- The returned vector is always of size `n_features`, so the docstring is misleading.

#### What testing did you do to verify the changes in this PR?
Added unit tests


<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
