### PR TITLE
Bugfixes for EvaluateModel and MatFileSampler

### DIFF
--- a/selene_sdk/evaluate_model.py
+++ b/selene_sdk/evaluate_model.py
@@ -150,14 +150,15 @@ class EvaluateModel(object):
         self._test_data, self._all_test_targets = \
             self.sampler.get_data_and_targets(self.batch_size, n_test_samples)
 
-        # remap indices
         self._use_testmat_ixs = self._use_ixs[:]
-        if self._all_test_targets.shape[1] == len(self._use_ixs) and \
-                sorted(self._use_ixs) != self._use_ixs:
-            subset_features = {features[ix]: i for (i, ix) in
+        # if the targets shape is the same as the subsetted features,
+        # reindex based on the subsetted list
+        if self._all_test_targets.shape[1] == len(self._use_ixs):
+            subset_features = {self.features[ix]: i for (i, ix) in
                                enumerate(sorted(self._use_ixs))}
             self._use_testmat_ixs = [
                 subset_features[f] for f in self.features[self._use_ixs]]
+
         self._all_test_targets = self._all_test_targets[
             :, self._use_testmat_ixs]
 

--- a/selene_sdk/evaluate_model.py
+++ b/selene_sdk/evaluate_model.py
@@ -156,7 +156,10 @@ class EvaluateModel(object):
         # here. the current workaround is problematic, since
         # self._test_data still has the full featureset in it, and we
         # select the subset during `evaluate`
-        self._all_test_targets = self._all_test_targets[:, self._use_ixs]
+        print(self._all_test_targets.shape)
+        if self._all_test_targets.shape[1] != len(self._use_ixs):
+            self._all_test_targets = self._all_test_targets[:, self._use_ixs]
+            print('filtering')
 
         # reset Genome base ordering when applicable.
         if (hasattr(self.sampler, "reference_sequence") and
@@ -211,7 +214,9 @@ class EvaluateModel(object):
         all_predictions = []
         for (inputs, targets) in self._test_data:
             inputs = torch.Tensor(inputs)
-            targets = torch.Tensor(targets[:, self._use_ixs])
+            if targets.shape[1] != len(self._use_ixs):
+                targets = targets[:, self._use_ixs]
+            targets = torch.Tensor(targets)
 
             if self.use_cuda:
                 inputs = inputs.cuda()

--- a/selene_sdk/evaluate_model.py
+++ b/selene_sdk/evaluate_model.py
@@ -59,7 +59,12 @@ class EvaluateModel(object):
         Default is None. Specify an ordered list of features for which to
         run the evaluation. The features in this list must be identical to or
         a subset of `features`, and in the order you want the resulting
-        `test_targets.npz` and `test_predictions.npz` to be saved.
+        `test_targets.npz` and `test_predictions.npz` to be saved. If using
+        a FileSampler or H5DataLoader for the evaluation, you can pass in
+        a dataset with the targets matrix only containing these features, but
+        note that this subsetted targets matrix MUST be ordered the same
+        way as `features`, and the predictions and targets .npz output
+        will be reordered according to `use_features_ord`.
 
     Attributes
     ----------

--- a/selene_sdk/samplers/file_samplers/mat_file_sampler.py
+++ b/selene_sdk/samplers/file_samplers/mat_file_sampler.py
@@ -105,8 +105,7 @@ class MatFileSampler(FileSampler):
             self._tgts_batch_axis = targets_batch_axis
         self.n_samples = self._sample_seqs.shape[self._seq_batch_axis]
 
-        self._sample_indices = np.arange(
-            self.n_samples).tolist()
+        self._sample_indices = np.arange(self.n_samples).tolist()
         self._sample_next = 0
 
         self._shuffle = shuffle
@@ -138,7 +137,7 @@ class MatFileSampler(FileSampler):
         """
         sample_up_to = self._sample_next + batch_size
         use_indices = None
-        if sample_up_to >= len(self._sample_indices):
+        if sample_up_to > len(self._sample_indices):
             if self._shuffle:
                 np.random.shuffle(self._sample_indices)
             self._sample_next = 0
@@ -237,19 +236,18 @@ class MatFileSampler(FileSampler):
                 "initialization. Please use `get_data` instead.")
         if not n_samples:
             n_samples = self.n_samples
+
         sequences_and_targets = []
         targets_mat = []
 
-        count = batch_size
+        count = 0
         while count < n_samples:
-            seqs, tgts = self.sample(batch_size=batch_size)
+            sample_size = min(n_samples - count, batch_size)
+            seqs, tgts = self.sample(batch_size=sample_size)
             sequences_and_targets.append((seqs, tgts))
             targets_mat.append(tgts)
-            count += batch_size
-        remainder = batch_size - (count - n_samples)
-        seqs, tgts = self.sample(batch_size=remainder)
-        sequences_and_targets.append((seqs, tgts))
-        targets_mat.append(tgts)
+            count += sample_size
+
         # TODO: should not assume targets are always integers
         targets_mat = np.vstack(targets_mat).astype(float)
         return sequences_and_targets, targets_mat

--- a/selene_sdk/utils/performance_metrics.py
+++ b/selene_sdk/utils/performance_metrics.py
@@ -316,7 +316,8 @@ class PerformanceMetrics(object):
     def __init__(self,
                  get_feature_from_index_fn,
                  report_gt_feature_n_positives=10,
-                 metrics=dict(roc_auc=roc_auc_score, average_precision=average_precision_score)):
+                 metrics=dict(roc_auc=roc_auc_score,
+                              average_precision=average_precision_score)):
         """
         Creates a new object of the `PerformanceMetrics` class.
         """

--- a/selene_sdk/utils/performance_metrics.py
+++ b/selene_sdk/utils/performance_metrics.py
@@ -250,7 +250,7 @@ def get_feature_specific_scores(data, get_feature_from_index_fn):
 
 def auc_u_test(labels, predictions):
     """
-    Outputs the area under the the ROC curve associated with a certain 
+    Outputs the area under the the ROC curve associated with a certain
     set of labels and the predictions given by the training model.
     Computed from the U statistic.
 
@@ -265,8 +265,8 @@ def auc_u_test(labels, predictions):
     Returns
     -------
     float
-        AUC value of given label, prediction pairs  
-   
+        AUC value of given label, prediction pairs
+
     """
     len_pos = int(np.sum(labels))
     len_neg = len(labels) - len_pos
@@ -467,7 +467,7 @@ class PerformanceMetrics(object):
         cols = '\t'.join(["class"] + metric_cols)
         with open(output_path, 'w+') as file_handle:
             file_handle.write("{0}\n".format(cols))
-            for feature, metric_scores in sorted(feature_scores.items()):
+            for feature, metric_scores in feature_scores.items():
                 if not metric_scores:
                     file_handle.write("{0}\t{1}\n".format(feature, "\t".join(["NA"] * len(metric_cols))))
                 else:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes bugs in EvaluateModel `use_features_ord` functionality (evaluating a model on only a subset of ordered targets) and MatFileSampler, which reset the pointer to what row to sample too early (i.e. supposed to do it when you've sampled all the rows in the matrix)

#### What does this implement/fix? Explain your changes.
See above

#### What testing did you do to verify the changes in this PR?
Ran EvaluateModel using MatFileSampler input data on 2 different cases, 1 subsetting chromatin features and 1 using the full set of features predicted by the model.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
