### PR TITLE
Bug fixes to parse learning rate from configs

### DIFF
--- a/selene_sdk/utils/config_utils.py
+++ b/selene_sdk/utils/config_utils.py
@@ -303,13 +303,16 @@ def parse_configs_and_run(configs,
     """
     operations = configs["ops"]
 
-    if "train" in operations and "lr" not in configs and lr != "None":
+    if "train" in operations and "lr" not in configs and lr != None:
         configs["lr"] = float(lr)
-    elif "train" in operations and "lr" in configs and lr != "None":
+    elif "train" in operations and "lr" in configs and lr != None:
         print("Warning: learning rate specified in both the "
               "configuration dict and this method's `lr` parameter. "
               "Using the `lr` value input to `parse_configs_and_run` "
               "({0}, not {1}).".format(lr, configs["lr"]))
+    elif "train" in operations and "lr" not in configs and lr == None:
+        raise ValueError("Learning rate not specified, cannot "
+                         "fit model. Exiting.")
 
     current_run_output_dir = None
     if "output_dir" not in configs and \


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #167 

#### What does this implement/fix? Explain your changes.
Fix parsing of configs file to check for `None` instead of `"None"`. Also check for the edge case when learning rate is not specified at all, in which case, a `ValueError` is thrown.

#### What testing did you do to verify the changes in this PR?
Read in `config_examples/train.yml` and then call `selene_sdk.utils.parse_configs_and_run` as-is (i.e. no learning rate), with a learning rate added to the function arguments, or a learning rate added to the configs.
