### PR TITLE
Additional seeding for reproducibility

### DIFF
--- a/selene_sdk/utils/config_utils.py
+++ b/selene_sdk/utils/config_utils.py
@@ -8,7 +8,9 @@ import importlib
 import sys
 from time import strftime
 import types
+import random
 
+import numpy as np
 import torch
 
 from . import _is_lua_trained_model
@@ -332,8 +334,12 @@ def parse_configs_and_run(configs,
 
     if "random_seed" in configs:
         seed = configs["random_seed"]
+        random.seed(seed)
+        np.random.seed(seed)
         torch.manual_seed(seed)
         torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
     else:
         print("Warning: no random seed specified in config file. "
               "Using a random seed ensures results are reproducible.")


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes issues with reproducibility when random seed is provided as discussed in the [Google group](https://groups.google.com/g/selene-sdk/c/MvGGuCT0ri0)

#### What does this implement/fix? Explain your changes.
Seed the Python and Numpy random number generator with the same seed used for Torch, and set torch to use deterministic algorithms.

#### What testing did you do to verify the changes in this PR?
Added these lines to a CLI script and ran Selene twice with the same input and same seed, and verified the output of the training loss and validation performance metrics was identical.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
