### PR TITLE
Bug fix for slicing bases_arr

### DIFF
--- a/selene_sdk/interpret/vis.py
+++ b/selene_sdk/interpret/vis.py
@@ -243,7 +243,7 @@ def sequence_logo(score_matrix, order="value", width=1.0, ax=None,
     # Change ordering of things based on input arguments.
     if order == "alpha":
         for i in range(score_matrix.shape[0]):
-            bases[i, :] = sequence_type.BASES_ARR[i]
+            bases[i, :] = np.array(sequence_type.BASES_ARR)[i]
 
     elif order == "value":
         if np.sum(score_matrix < 0) != 0:
@@ -256,7 +256,7 @@ def sequence_logo(score_matrix, order="value", width=1.0, ax=None,
                                                axis=None)
                 sorted_scores[:div, j] = score_matrix[
                     negative_idx[negative_sort_idx], j]
-                bases[:div, j] = sequence_type.BASES_ARR[
+                bases[:div, j] = np.array(sequence_type.BASES_ARR)[
                     negative_idx[negative_sort_idx]].flatten()
 
                 # Sort the positive values and stack atop the negatives.
@@ -265,13 +265,13 @@ def sequence_logo(score_matrix, order="value", width=1.0, ax=None,
                                                axis=None)
                 sorted_scores[div:, j] = score_matrix[
                     positive_idx[positive_sort_idx], j]
-                bases[div:, j] = sequence_type.BASES_ARR[
+                bases[div:, j] = np.array(sequence_type.BASES_ARR)[
                     positive_idx[positive_sort_idx]].flatten()
             score_matrix = sorted_scores
         else:
             for j in range(score_matrix.shape[1]):
                 sort_idx = np.argsort(score_matrix[:, j], axis=None)[::-1]
-                bases[:, j] = sequence_type.BASES_ARR[sort_idx]
+                bases[:, j] = np.array(sequence_type.BASES_ARR)[sort_idx]
                 score_matrix[:, j] = score_matrix[sort_idx, j]
 
     # Create offsets for each bar.


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #174 

#### What does this implement/fix? Explain your changes.
Fixed a type error when creating a sequence logo with `order == "value"`. Slicing `BASES_ARR` did not work here because it was slicing with an ndarray and `BASES_ARR` is a pure list. For now, I just cast it as an ndarray in each place this happens (4 times).

#### What testing did you do to verify the changes in this PR?
Create a sequence logo from ISM results. Code successfully ran and generated a logo.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
