### PR TITLE
Allow for assessing performance in multi-class classification setting

### DIFF
--- a/selene_sdk/utils/performance_metrics.py
+++ b/selene_sdk/utils/performance_metrics.py
@@ -200,7 +200,12 @@ def compute_score(prediction, target, metric_fn,
         `(None, [])`.
     """
     feature_scores = np.ones(target.shape[1]) * np.nan
-    for index, feature_preds in enumerate(prediction.T):
+    # Deal with the case of multi-class classification, where each example only has one target value but multiple prediction values
+    if target.shape[1] == 1 and prediction.shape[1] > 1:
+        prediction = [prediction]
+    else:
+        prediction = prediction.T
+    for index, feature_preds in enumerate(prediction):
         feature_targets = target[:, index]
         if len(np.unique(feature_targets)) > 0 and \
                np.count_nonzero(feature_targets) > report_gt_feature_n_positives:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
No issue to reference.

#### What does this implement/fix? Explain your changes.
In the case of multi-class classification, each prediction task is not entirely separate. A user might want to compute the micro average of the ROC or PR curves, or compute the F1 score (micro or macro averaged). Computing these metrics requires knowledge of all targets and all predictions, at the same time. Currently the implementation does not allow this because it loops over each column of predictions separately, computes performance metrics, and then averages them together at the end.

I added a condition to the `compute_score` function that allows for this. In the config file, the user specifies the targets as single values (i.e. a column vector). The NN will output `K` predictions per example, corresponding to the probability that the example belongs to each of `K` classes.

Performance of the original implementation can be rescued by either (1) one-hot encoding the targets or (2) using implementations of performance metrics that use macro averaging, and specifying them in the config file.

#### What testing did you do to verify the changes in this PR?
Ran Selene using data where `targets` is a column vector of integer values `0,...,K-1` and NN architecture outputs `K` values for each example, corresponding to probabilities of the example belonging to each of the `K` classes. Wrote custom wrappers of performance metrics and confirmed that the metrics are only called once per epoch, rather than `K` times.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
