### PR TITLE
add isinstance check of Sampler to FileSampler in MultiSampler class

### DIFF
--- a/selene_sdk/samplers/multi_sampler.py
+++ b/selene_sdk/samplers/multi_sampler.py
@@ -8,6 +8,7 @@ import numpy as np
 from torch.utils.data import DataLoader
 
 from .sampler import Sampler
+from .file_samplers import FileSampler
 
 
 def MultiFileSampler(*args, **kwargs):
@@ -88,11 +89,10 @@ class MultiSampler(Sampler):
             features,
             save_datasets=save_datasets,
             output_dir=output_dir)
-
         self._samplers = {
-            "train": train_sampler if isinstance(train_sampler, Sampler) \
+            "train": train_sampler if isinstance(train_sampler, FileSampler) \
                      else None,
-            "validate": validate_sampler if isinstance(validate_sampler, Sampler) \
+            "validate": validate_sampler if isinstance(validate_sampler, FileSampler) \
                         else None
         }
 
@@ -115,7 +115,7 @@ class MultiSampler(Sampler):
         if test_sampler is not None:
             self.modes.append("test")
             self._samplers["test"] = \
-                test_sampler if isinstance(test_sampler, Sampler) else None
+                test_sampler if isinstance(test_sampler, FileSampler) else None
             self._dataloaders["test"] = \
                 test_sampler if isinstance(test_sampler, DataLoader) else None
             self._iterators["test"] = iter(self._dataloaders["test"]) \

--- a/selene_sdk/samplers/multi_sampler.py
+++ b/selene_sdk/samplers/multi_sampler.py
@@ -90,9 +90,11 @@ class MultiSampler(Sampler):
             save_datasets=save_datasets,
             output_dir=output_dir)
         self._samplers = {
-            "train": train_sampler if isinstance(train_sampler, FileSampler) \
+            "train": train_sampler if (isinstance(train_sampler, FileSampler) or
+                                       isinstance(train_sampler, Sampler)) \
                      else None,
-            "validate": validate_sampler if isinstance(validate_sampler, FileSampler) \
+            "validate": validate_sampler if (isinstance(validate_sampler, FileSampler) or
+                                             isinstance(validate_sampler, Sampler)) \
                         else None
         }
 
@@ -115,7 +117,8 @@ class MultiSampler(Sampler):
         if test_sampler is not None:
             self.modes.append("test")
             self._samplers["test"] = \
-                test_sampler if isinstance(test_sampler, FileSampler) else None
+                test_sampler if (isinstance(test_sampler, FileSampler) or
+                                 isinstance(test_sampler, Sampler)) else None
             self._dataloaders["test"] = \
                 test_sampler if isinstance(test_sampler, DataLoader) else None
             self._iterators["test"] = iter(self._dataloaders["test"]) \


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Bug in MultiSampler where we only check that the input samplers are of type Sampler and not also FileSampler

#### What does this implement/fix? Explain your changes.
changed the `isinstance` check 

#### What testing did you do to verify the changes in this PR?
Re-ran an example where we use MultiSampler with MatFileSampler class

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
