### PR TITLE
Early stopping and other parameters for learning rate scheduler

### DIFF
--- a/config_examples/train_scheduler_early_stopping.yml
+++ b/config_examples/train_scheduler_early_stopping.yml
@@ -1,0 +1,46 @@
+---
+ops: [train]
+create_subdirectory: False
+lr: 0.0003
+model: {
+    path: ./Data/SeleneFiles/enhancer_resnet_regression.py,
+    class: EnhancerResnet,
+    class_args: {
+        sequence_length: 164,
+    },
+    #non_strand_specific: "mean",
+}
+sampler: !obj:selene_sdk.samplers.MultiSampler {
+    features: ["expression_log2_standardized"],
+    train_sampler: !obj:selene_sdk.samplers.file_samplers.MatFileSampler {
+        filepath: ./Data/SeleneFiles/train_regression.mat,
+        sequence_key: sequence,
+        targets_key: activity,
+        shuffle: True,
+    },
+    validate_sampler: !obj:selene_sdk.samplers.file_samplers.MatFileSampler {
+        filepath: ./Data/SeleneFiles/validate_regression.mat,
+        sequence_key: sequence,
+        targets_key: activity,
+        shuffle: False,
+    },
+}
+train_model: !obj:selene_sdk.TrainModel {
+    batch_size: 128,  # 25757 training examples
+    report_stats_every_n_steps: 202,  # 201.23 steps for full epoch
+    max_steps: 10062,   # 50 epochs
+    use_cuda: True,
+    data_parallel: False,
+    logging_verbosity: 2,
+    metrics: {
+      pcc: !import metrics.pearson,
+      scc: !import metrics.spearman,
+    },
+    scheduler_kwargs: {
+      patience: 3,
+      factor: 0.2,
+      verbose: True,
+    },
+    stopping_criteria: ["scc", 10],
+}
+...


### PR DESCRIPTION
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #183 


#### What does this implement/fix? Explain your changes.
1. Added support for other parameters for `ReduceLROnPlateau`. The `TrainModel` object has a new argument `scheduler_kwargs` that defaults to the pre-existing default parameters. User can specify other parameters as a dictionary, including through YAML config files. The kwargs get passed to the `_init_train` method when the scheduler is created. Support for other types of schedulers was not added.
2. Added support for early stopping. The `TrainModel` object has a new optional argument `stopping_criteria`. If specified, it is a list that must correspond to the metric and patience for stopping criteria. When `validate` is called, it checks to see the last time the specified metric improves on the validation set. If the metric has not improved in the specified patience period, then the logger reports a debug message that early stopping has been reached and the for loop in `train_and_validate` is terminated.

#### What testing did you do to verify the changes in this PR?
1. Created `TrainModel` objects from YAML config files that contain the new arguments. Verified the `scheduler` is assigned parameters specified in the config. Verified the early stopping criteria gets set as internal variables.
2. I had previously implemented the early stopping code as a hack in my own scripts and verified that the criteria can be reached and stops training early. Code implemented here is virtually identical to what I had used in my scripts.

<!--
We value all user contributions, no matter how minor they are. 

Thanks for contributing!
-->
